### PR TITLE
feat: add training application page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,7 @@ import NotFound from "@/pages/not-found";
 import ServerError from "./pages/ServerError";
 import ErrorTest from "./pages/ErrorTest";
 import { useState } from "react";
+import Learn from "./pages/Learn";
 
 function Router() {
   return (
@@ -29,6 +30,8 @@ function Router() {
         <Route path="/" component={Home} />
         <Route path="/secteurs-activite" component={ActivitySectors} />
         <Route path="/services" component={Services} />
+        <Route path="/learn" component={Learn} />
+        <Route path="/apprendre" component={Learn} />
         <Route path="/contact" component={Contact} />
         <Route path="/public-safety" component={PublicSafety} />
         <Route path="/francophone-services" component={FrancophoneServices} />

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -12,6 +12,7 @@ export interface TranslationData {
     home: string;
     divisions: string;
     services: string;
+    learn: string;
     contact: string;
   };
   hero: {
@@ -70,6 +71,78 @@ export interface TranslationData {
     ctaTitle: string;
     ctaDescription: string;
     ctaButton: string;
+  };
+  learn: {
+    title: string;
+    subtitle: string;
+    intro: string;
+    highlights: {
+      title: string;
+      description: string;
+    }[];
+    benefits: {
+      title: string;
+      items: string[];
+    };
+    form: {
+      title: string;
+      description: string;
+      personal: {
+        title: string;
+        firstName: string;
+        lastName: string;
+        dateOfBirth: string;
+        address: string;
+        phoneNumber: string;
+        email: string;
+        placeholders: {
+          firstName: string;
+          lastName: string;
+          dateOfBirth: string;
+          address: string;
+          phoneNumber: string;
+          email: string;
+        };
+      };
+      employment: {
+        title: string;
+        description: string;
+        options: {
+          employee: string;
+          jobSeeker: string;
+          student: string;
+          selfEmployed: string;
+          other: string;
+        };
+        otherPlaceholder: string;
+      };
+      motivations: {
+        title: string;
+        motivationsLabel: string;
+        careerGoalsLabel: string;
+        motivationsPlaceholder: string;
+        careerGoalsPlaceholder: string;
+      };
+      declaration: {
+        title: string;
+        text: string;
+        checkbox: string;
+        fullNamePlaceholder: string;
+      };
+      submit: string;
+      successTitle: string;
+      successMessage: string;
+      errors: {
+        required: string;
+        email: string;
+        phone: string;
+        declaration: string;
+        otherRequired: string;
+        motivationsLength: string;
+        careerLength: string;
+        tooFast: string;
+      };
+    };
   };
   contact: {
     title: string;

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -7,6 +7,7 @@
     "home": "Home",
     "divisions": "Activity Sectors",
     "services": "Services",
+    "learn": "Learn",
     "contact": "Contact"
   },
   "hero": {
@@ -65,6 +66,92 @@
     "ctaTitle": "Ready to start your project?",
     "ctaDescription": "Let's discuss your needs and discover how our services can transform your organization.",
     "ctaButton": "Get a free consultation"
+  },
+  "learn": {
+    "title": "Professional Training Programs",
+    "subtitle": "Advance your career with bilingual courses tailored for safety and community leaders.",
+    "intro": "Our training division delivers applied learning experiences that combine regulatory knowledge, scenario-based practice, and strategic coaching for individuals ready to elevate their impact.",
+    "highlights": [
+      {
+        "title": "Hands-on scenarios",
+        "description": "Scenario-based workshops that replicate real incidents in public safety, occupational health, and community services."
+      },
+      {
+        "title": "Certified instructors",
+        "description": "Courses delivered by bilingual experts with frontline experience across Canada and recognized accreditations."
+      },
+      {
+        "title": "Career support",
+        "description": "Personalized guidance to align the training path with your professional ambitions and next career steps."
+      }
+    ],
+    "benefits": {
+      "title": "What you will gain",
+      "items": [
+        "Up-to-date competencies that reflect Canadian standards for safety, health, and community programming.",
+        "Coaching to translate classroom learning into immediate workplace impact.",
+        "Access to the Rémi Guillette Group professional network for continued mentorship."
+      ]
+    },
+    "form": {
+      "title": "Training Application Form",
+      "description": "Complete the application below so our admissions team can follow up with you.",
+      "personal": {
+        "title": "Personal Information",
+        "firstName": "First Name",
+        "lastName": "Last Name",
+        "dateOfBirth": "Date of Birth",
+        "address": "Full Address",
+        "phoneNumber": "Phone Number",
+        "email": "Email Address",
+        "placeholders": {
+          "firstName": "Your first name",
+          "lastName": "Your last name",
+          "dateOfBirth": "YYYY-MM-DD",
+          "address": "123 Main Street, City, Province",
+          "phoneNumber": "(123) 456-7890",
+          "email": "your@email.com"
+        }
+      },
+      "employment": {
+        "title": "Current Employment Status",
+        "description": "Current Status *",
+        "options": {
+          "employee": "Employee",
+          "jobSeeker": "Job Seeker",
+          "student": "Student",
+          "selfEmployed": "Self-Employed / Entrepreneur",
+          "other": "Other (please specify)"
+        },
+        "otherPlaceholder": "Please specify your status"
+      },
+      "motivations": {
+        "title": "Motivations and Career Plan",
+        "motivationsLabel": "Why do you want to take this training? What are your motivations? *",
+        "careerGoalsLabel": "What are your professional goals after completing this training? *",
+        "motivationsPlaceholder": "Share what drives you to enrol in this program...",
+        "careerGoalsPlaceholder": "Describe the career path you plan to pursue after the training..."
+      },
+      "declaration": {
+        "title": "Declaration",
+        "text": "I, the undersigned, {{fullName}}, certify that the information provided in this form is accurate and complete.",
+        "checkbox": "I confirm that the information provided is accurate.",
+        "fullNamePlaceholder": "your full name"
+      },
+      "submit": "Submit Application",
+      "successTitle": "Application submitted",
+      "successMessage": "Thank you for applying! Our team will contact you soon.",
+      "errors": {
+        "required": "Please fill in all required fields.",
+        "email": "Please enter a valid email address.",
+        "phone": "Please enter a phone number with at least 10 digits.",
+        "declaration": "You must accept the declaration to submit your application.",
+        "otherRequired": "Please specify your current status.",
+        "motivationsLength": "Please provide at least 20 characters for your motivations.",
+        "careerLength": "Please provide at least 20 characters for your career goals.",
+        "tooFast": "Please take a few moments to complete the form before submitting."
+      }
+    }
   },
   "contact": {
     "title": "Contact Us",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -7,6 +7,7 @@
     "home": "Accueil",
     "divisions": "Secteurs d'activité",
     "services": "Services",
+    "learn": "Formations",
     "contact": "Contact"
   },
   "hero": {
@@ -65,6 +66,92 @@
     "ctaTitle": "Prêt à commencer votre projet?",
     "ctaDescription": "Discutons de vos besoins et découvrons comment nos services peuvent transformer votre organisation.",
     "ctaButton": "Obtenir une consultation gratuite"
+  },
+  "learn": {
+    "title": "Programmes de formation professionnelle",
+    "subtitle": "Faites progresser votre carrière avec des parcours bilingues adaptés aux leaders de la sécurité et des services communautaires.",
+    "intro": "Notre division formation propose des expériences d'apprentissage appliquées qui combinent connaissances réglementaires, mises en situation et accompagnement stratégique pour amplifier votre impact.",
+    "highlights": [
+      {
+        "title": "Scénarios pratiques",
+        "description": "Ateliers basés sur des scénarios reproduisant des situations réelles en sécurité publique, santé et services communautaires."
+      },
+      {
+        "title": "Formateurs certifiés",
+        "description": "Des experts bilingues possédant une expérience terrain à travers le Canada et des accréditations reconnues."
+      },
+      {
+        "title": "Accompagnement de carrière",
+        "description": "Un guidage personnalisé pour aligner la formation sur vos ambitions professionnelles et vos prochaines étapes."
+      }
+    ],
+    "benefits": {
+      "title": "Ce que vous retirerez",
+      "items": [
+        "Des compétences actualisées conformes aux normes canadiennes en sécurité, santé et programmation communautaire.",
+        "Un coaching pour transformer les apprentissages en résultats concrets sur le terrain.",
+        "L'accès au réseau professionnel du Groupe Rémi Guillette pour un mentorat continu."
+      ]
+    },
+    "form": {
+      "title": "Formulaire de demande de formation",
+      "description": "Remplissez la demande ci-dessous afin que notre équipe d'admission puisse vous contacter.",
+      "personal": {
+        "title": "Renseignements personnels",
+        "firstName": "Prénom",
+        "lastName": "Nom",
+        "dateOfBirth": "Date de naissance",
+        "address": "Adresse complète",
+        "phoneNumber": "Numéro de téléphone",
+        "email": "Adresse courriel",
+        "placeholders": {
+          "firstName": "Votre prénom",
+          "lastName": "Votre nom",
+          "dateOfBirth": "AAAA-MM-JJ",
+          "address": "123 rue Principale, Ville, Province",
+          "phoneNumber": "(123) 456-7890",
+          "email": "votre@email.com"
+        }
+      },
+      "employment": {
+        "title": "Statut professionnel actuel",
+        "description": "Statut actuel *",
+        "options": {
+          "employee": "Employé(e)",
+          "jobSeeker": "Chercheur d'emploi",
+          "student": "Étudiant(e)",
+          "selfEmployed": "Travailleur autonome / Entrepreneur",
+          "other": "Autre (veuillez préciser)"
+        },
+        "otherPlaceholder": "Veuillez préciser votre statut"
+      },
+      "motivations": {
+        "title": "Motivations et plan de carrière",
+        "motivationsLabel": "Pourquoi souhaitez-vous suivre cette formation? Quelles sont vos motivations? *",
+        "careerGoalsLabel": "Quels sont vos objectifs professionnels après la formation? *",
+        "motivationsPlaceholder": "Expliquez ce qui vous motive à intégrer ce programme...",
+        "careerGoalsPlaceholder": "Décrivez le parcours professionnel que vous envisagez après la formation..."
+      },
+      "declaration": {
+        "title": "Déclaration",
+        "text": "Je soussigné(e), {{fullName}}, certifie que les renseignements fournis dans ce formulaire sont exacts et complets.",
+        "checkbox": "Je confirme que les renseignements fournis sont exacts.",
+        "fullNamePlaceholder": "vos prénom et nom"
+      },
+      "submit": "Soumettre la demande",
+      "successTitle": "Demande envoyée",
+      "successMessage": "Merci pour votre intérêt! Notre équipe vous contactera prochainement.",
+      "errors": {
+        "required": "Veuillez remplir tous les champs obligatoires.",
+        "email": "Veuillez saisir une adresse courriel valide.",
+        "phone": "Veuillez saisir un numéro de téléphone d'au moins 10 chiffres.",
+        "declaration": "Vous devez accepter la déclaration pour soumettre votre demande.",
+        "otherRequired": "Veuillez préciser votre statut actuel.",
+        "motivationsLength": "Veuillez fournir au moins 20 caractères pour vos motivations.",
+        "careerLength": "Veuillez fournir au moins 20 caractères pour vos objectifs professionnels.",
+        "tooFast": "Prenez quelques instants pour compléter le formulaire avant de l'envoyer."
+      }
+    }
   },
   "contact": {
     "title": "Contactez-Nous",

--- a/client/src/pages/Learn.tsx
+++ b/client/src/pages/Learn.tsx
@@ -1,0 +1,540 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from '../contexts/TranslationContext';
+import { useToast } from '../hooks/use-toast';
+import { useMutation } from '@tanstack/react-query';
+import { apiRequest } from '../lib/queryClient';
+import { useScrollToTop } from '../hooks/useScrollToTop';
+import { BadgeCheck, CheckCircle, GraduationCap, Rocket } from 'lucide-react';
+
+type FormState = {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  address: string;
+  phoneNumber: string;
+  email: string;
+  employmentStatus: string;
+  employmentStatusOther: string;
+  motivations: string;
+  careerGoals: string;
+  declarationAccepted: boolean;
+};
+
+const initialFormState: FormState = {
+  firstName: '',
+  lastName: '',
+  dateOfBirth: '',
+  address: '',
+  phoneNumber: '',
+  email: '',
+  employmentStatus: '',
+  employmentStatusOther: '',
+  motivations: '',
+  careerGoals: '',
+  declarationAccepted: false,
+};
+
+export default function Learn() {
+  const { t, language } = useTranslation();
+  const { toast } = useToast();
+  useScrollToTop();
+  const submitButtonRef = useRef<HTMLButtonElement>(null);
+  const [formData, setFormData] = useState<FormState>(initialFormState);
+  const [formStartTime] = useState(() => Date.now());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!submitButtonRef.current) return;
+
+    let angle = 0;
+    let animationFrameId: number;
+
+    const rotateGradient = () => {
+      angle = (angle + 1) % 360;
+      if (submitButtonRef.current) {
+        submitButtonRef.current.style.setProperty('--gradient-angle', `${angle}deg`);
+      }
+      animationFrameId = requestAnimationFrame(rotateGradient);
+    };
+
+    rotateGradient();
+
+    return () => {
+      if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId);
+      }
+    };
+  }, []);
+
+  const employmentOptions = useMemo(
+    () => [
+      { value: 'employee', label: t.learn.form.employment.options.employee },
+      { value: 'jobSeeker', label: t.learn.form.employment.options.jobSeeker },
+      { value: 'student', label: t.learn.form.employment.options.student },
+      { value: 'selfEmployed', label: t.learn.form.employment.options.selfEmployed },
+      { value: 'other', label: t.learn.form.employment.options.other },
+    ],
+    [t.learn.form.employment.options]
+  );
+
+  const highlightIcons = useMemo(() => [GraduationCap, BadgeCheck, Rocket], []);
+
+  const errorTitle = language === 'fr' ? 'Erreur' : 'Error';
+
+  const applicationMutation = useMutation({
+    mutationFn: async (data: FormState) => {
+      const submissionData = {
+        ...data,
+        formStartTime: formStartTime.toString(),
+        website: '',
+        url: '',
+        phone_hidden: '',
+      };
+
+      const response = await apiRequest('POST', '/api/training-applications', submissionData);
+      return response.json();
+    },
+    onSuccess: () => {
+      setIsSubmitting(false);
+      toast({
+        title: t.learn.form.successTitle,
+        description: t.learn.form.successMessage,
+      });
+      setFormData({ ...initialFormState });
+    },
+    onError: (error: any) => {
+      setIsSubmitting(false);
+      console.error('Training application error:', error);
+      const fallbackMessage = language === 'fr'
+        ? "Une erreur est survenue lors de l'envoi de votre demande. Veuillez réessayer."
+        : 'An error occurred while submitting your application. Please try again.';
+      const errorMessage = error?.message || fallbackMessage;
+      toast({
+        title: errorTitle,
+        description: errorMessage,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value, type, checked } = event.target;
+
+    if (type === 'checkbox') {
+      setFormData((prev) => ({
+        ...prev,
+        [name]: checked,
+      }));
+      return;
+    }
+
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleEmploymentChange = (value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      employmentStatus: value,
+      employmentStatusOther: value === 'other' ? prev.employmentStatusOther : '',
+    }));
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isSubmitting || applicationMutation.isPending) {
+      return;
+    }
+
+    const timeSinceLoad = Date.now() - formStartTime;
+    if (timeSinceLoad < 3000) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.tooFast,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const requiredFields: (keyof FormState)[] = [
+      'firstName',
+      'lastName',
+      'dateOfBirth',
+      'address',
+      'phoneNumber',
+      'email',
+      'employmentStatus',
+      'motivations',
+      'careerGoals',
+    ];
+
+    const hasEmptyRequired = requiredFields.some((field) => !String(formData[field]).trim());
+    if (hasEmptyRequired) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.required,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (
+      formData.employmentStatus === 'other' &&
+      !formData.employmentStatusOther.trim()
+    ) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.otherRequired,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(formData.email)) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.email,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const phoneDigits = formData.phoneNumber.replace(/\D/g, '');
+    if (phoneDigits.length < 10) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.phone,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (formData.motivations.trim().length < 20) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.motivationsLength,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (formData.careerGoals.trim().length < 20) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.careerLength,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (!formData.declarationAccepted) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.declaration,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const submission: FormState = {
+      ...formData,
+      address: formData.address.trim(),
+      phoneNumber: formData.phoneNumber.trim(),
+      email: formData.email.trim(),
+      motivations: formData.motivations.trim(),
+      careerGoals: formData.careerGoals.trim(),
+      employmentStatusOther:
+        formData.employmentStatus === 'other'
+          ? formData.employmentStatusOther.trim()
+          : '',
+    };
+
+    applicationMutation.mutate(submission);
+  };
+
+  const fullNameForDeclaration = [formData.firstName.trim(), formData.lastName.trim()]
+    .filter(Boolean)
+    .join(' ') || t.learn.form.declaration.fullNamePlaceholder;
+  const declarationText = t.learn.form.declaration.text.replace('{{fullName}}', fullNameForDeclaration);
+
+  return (
+    <main className="bg-rg-dark-bg min-h-screen w-full py-16 text-white">
+      <div className="container-responsive space-y-16">
+        <header className="text-center space-y-6 max-w-4xl mx-auto">
+          <h1 className="text-4xl md:text-5xl font-bold" style={{ color: '#f89422' }}>
+            {t.learn.title}
+          </h1>
+          <p className="text-xl text-gray-300">{t.learn.subtitle}</p>
+          <p className="text-lg text-gray-300 leading-relaxed">{t.learn.intro}</p>
+        </header>
+
+        <section className="grid gap-6 md:grid-cols-3">
+          {t.learn.highlights.map((highlight, index) => {
+            const Icon = highlightIcons[index % highlightIcons.length];
+            return (
+              <div
+                key={highlight.title}
+                className="bg-rg-card-bg border border-rg-gray rounded-2xl p-6 h-full flex flex-col"
+              >
+                <div className="w-14 h-14 rounded-xl bg-gradient-to-br from-orange-500 to-blue-500 flex items-center justify-center mb-4">
+                  <Icon className="w-7 h-7 text-white" aria-hidden="true" />
+                </div>
+                <h3 className="text-xl font-semibold mb-3" style={{ color: '#f89422' }}>
+                  {highlight.title}
+                </h3>
+                <p className="text-gray-300 leading-relaxed">
+                  {highlight.description}
+                </p>
+              </div>
+            );
+          })}
+        </section>
+
+        <section className="bg-rg-card-bg border border-rg-gray rounded-2xl p-8">
+          <h2 className="text-3xl font-bold mb-6" style={{ color: '#f89422' }}>
+            {t.learn.benefits.title}
+          </h2>
+          <ul className="space-y-4">
+            {t.learn.benefits.items.map((item, index) => (
+              <li key={index} className="flex items-start text-gray-300">
+                <CheckCircle className="w-5 h-5 text-[#f89422] mt-1 mr-3" aria-hidden="true" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="bg-rg-card-bg border border-rg-gray rounded-2xl p-8">
+          <h2 className="text-3xl font-bold mb-4" style={{ color: '#f89422' }}>
+            {t.learn.form.title}
+          </h2>
+          <p className="text-gray-300 mb-8">{t.learn.form.description}</p>
+
+          <form onSubmit={handleSubmit} className="space-y-10">
+            <fieldset className="space-y-6">
+              <legend className="text-2xl font-semibold" style={{ color: '#f89422' }}>
+                {t.learn.form.personal.title}
+              </legend>
+              <div className="grid gap-6 md:grid-cols-2">
+                <div>
+                  <label htmlFor="firstName" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.personal.firstName}
+                  </label>
+                  <input
+                    id="firstName"
+                    name="firstName"
+                    type="text"
+                    value={formData.firstName}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.personal.placeholders.firstName}
+                    autoComplete="given-name"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="lastName" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.personal.lastName}
+                  </label>
+                  <input
+                    id="lastName"
+                    name="lastName"
+                    type="text"
+                    value={formData.lastName}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.personal.placeholders.lastName}
+                    autoComplete="family-name"
+                  />
+                </div>
+              </div>
+              <div className="grid gap-6 md:grid-cols-2">
+                <div>
+                  <label htmlFor="dateOfBirth" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.personal.dateOfBirth}
+                  </label>
+                  <input
+                    id="dateOfBirth"
+                    name="dateOfBirth"
+                    type="date"
+                    value={formData.dateOfBirth}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.personal.placeholders.dateOfBirth}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="phoneNumber" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.personal.phoneNumber}
+                  </label>
+                  <input
+                    id="phoneNumber"
+                    name="phoneNumber"
+                    type="tel"
+                    value={formData.phoneNumber}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.personal.placeholders.phoneNumber}
+                    autoComplete="tel"
+                  />
+                </div>
+              </div>
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="md:col-span-2">
+                  <label htmlFor="address" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.personal.address}
+                  </label>
+                  <input
+                    id="address"
+                    name="address"
+                    type="text"
+                    value={formData.address}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.personal.placeholders.address}
+                    autoComplete="street-address"
+                  />
+                </div>
+                <div className="md:col-span-2">
+                  <label htmlFor="email" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.personal.email}
+                  </label>
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    value={formData.email}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.personal.placeholders.email}
+                    autoComplete="email"
+                  />
+                </div>
+              </div>
+            </fieldset>
+
+            <fieldset className="space-y-6">
+              <legend className="text-2xl font-semibold" style={{ color: '#f89422' }}>
+                {t.learn.form.employment.title}
+              </legend>
+              <p className="text-sm text-gray-400">{t.learn.form.employment.description}</p>
+              <div className="space-y-3">
+                {employmentOptions.map((option) => (
+                  <label
+                    key={option.value}
+                    className={`flex items-center justify-between rounded-lg px-4 py-3 transition-colors border-2 ${
+                      formData.employmentStatus === option.value
+                        ? 'border-[#f89422] bg-black'
+                        : 'border-[#1f2937] bg-black/40 hover:border-[#f89422]/60'
+                    }`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <input
+                        type="radio"
+                        name="employmentStatus"
+                        value={option.value}
+                        checked={formData.employmentStatus === option.value}
+                        onChange={() => handleEmploymentChange(option.value)}
+                        className="h-4 w-4 text-[#f89422] focus:ring-[#f89422]"
+                      />
+                      <span className="text-white">{option.label}</span>
+                    </div>
+                    {formData.employmentStatus === option.value && (
+                      <CheckCircle className="w-5 h-5 text-[#f89422]" aria-hidden="true" />
+                    )}
+                  </label>
+                ))}
+              </div>
+
+              {formData.employmentStatus === 'other' && (
+                <div>
+                  <label htmlFor="employmentStatusOther" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.employment.options.other}
+                  </label>
+                  <input
+                    id="employmentStatusOther"
+                    name="employmentStatusOther"
+                    type="text"
+                    value={formData.employmentStatusOther}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.employment.otherPlaceholder}
+                  />
+                </div>
+              )}
+            </fieldset>
+
+            <fieldset className="space-y-6">
+              <legend className="text-2xl font-semibold" style={{ color: '#f89422' }}>
+                {t.learn.form.motivations.title}
+              </legend>
+              <div>
+                <label htmlFor="motivations" className="block text-sm font-medium mb-2 text-gray-300">
+                  {t.learn.form.motivations.motivationsLabel}
+                </label>
+                <textarea
+                  id="motivations"
+                  name="motivations"
+                  rows={4}
+                  value={formData.motivations}
+                  onChange={handleInputChange}
+                  className="w-full px-4 py-4 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent resize-none"
+                  placeholder={t.learn.form.motivations.motivationsPlaceholder}
+                />
+              </div>
+              <div>
+                <label htmlFor="careerGoals" className="block text-sm font-medium mb-2 text-gray-300">
+                  {t.learn.form.motivations.careerGoalsLabel}
+                </label>
+                <textarea
+                  id="careerGoals"
+                  name="careerGoals"
+                  rows={4}
+                  value={formData.careerGoals}
+                  onChange={handleInputChange}
+                  className="w-full px-4 py-4 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent resize-none"
+                  placeholder={t.learn.form.motivations.careerGoalsPlaceholder}
+                />
+              </div>
+            </fieldset>
+
+            <fieldset className="space-y-4">
+              <legend className="text-2xl font-semibold" style={{ color: '#f89422' }}>
+                {t.learn.form.declaration.title}
+              </legend>
+              <p className="text-gray-300 leading-relaxed">{declarationText}</p>
+              <label className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  name="declarationAccepted"
+                  checked={formData.declarationAccepted}
+                  onChange={handleInputChange}
+                  className="mt-1 h-5 w-5 text-[#f89422] focus:ring-[#f89422]"
+                />
+                <span className="text-gray-300">{t.learn.form.declaration.checkbox}</span>
+              </label>
+            </fieldset>
+
+            <button
+              ref={submitButtonRef}
+              type="submit"
+              disabled={isSubmitting || applicationMutation.isPending}
+              className="border-gradient-button w-full md:w-auto px-8 py-4 text-white font-semibold rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting || applicationMutation.isPending
+                ? language === 'fr'
+                  ? 'Envoi en cours...'
+                  : 'Submitting...'
+                : t.learn.form.submit}
+            </button>
+          </form>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,10 +1,13 @@
-import { 
-  users, 
+import {
+  users,
   contactMessages,
-  type User, 
+  trainingApplications,
+  type User,
   type InsertUser,
   type ContactMessage,
-  type InsertContactMessage
+  type InsertContactMessage,
+  type TrainingApplication,
+  type InsertTrainingApplication
 } from "@shared/schema";
 
 export interface IStorage {
@@ -13,19 +16,25 @@ export interface IStorage {
   createUser(user: InsertUser): Promise<User>;
   createContactMessage(message: InsertContactMessage): Promise<ContactMessage>;
   getContactMessages(): Promise<ContactMessage[]>;
+  createTrainingApplication(application: InsertTrainingApplication): Promise<TrainingApplication>;
+  getTrainingApplications(): Promise<TrainingApplication[]>;
 }
 
 export class MemStorage implements IStorage {
   private users: Map<number, User>;
   private contactMessages: Map<number, ContactMessage>;
+  private trainingApplications: Map<number, TrainingApplication>;
   private currentUserId: number;
   private currentMessageId: number;
+  private currentApplicationId: number;
 
   constructor() {
     this.users = new Map();
     this.contactMessages = new Map();
+    this.trainingApplications = new Map();
     this.currentUserId = 1;
     this.currentMessageId = 1;
+    this.currentApplicationId = 1;
   }
 
   async getUser(id: number): Promise<User | undefined> {
@@ -47,8 +56,8 @@ export class MemStorage implements IStorage {
 
   async createContactMessage(insertMessage: InsertContactMessage): Promise<ContactMessage> {
     const id = this.currentMessageId++;
-    const message: ContactMessage = { 
-      ...insertMessage, 
+    const message: ContactMessage = {
+      ...insertMessage,
       id,
       createdAt: new Date()
     };
@@ -58,6 +67,23 @@ export class MemStorage implements IStorage {
 
   async getContactMessages(): Promise<ContactMessage[]> {
     return Array.from(this.contactMessages.values()).sort(
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+    );
+  }
+
+  async createTrainingApplication(insertApplication: InsertTrainingApplication): Promise<TrainingApplication> {
+    const id = this.currentApplicationId++;
+    const application: TrainingApplication = {
+      ...insertApplication,
+      id,
+      createdAt: new Date()
+    };
+    this.trainingApplications.set(id, application);
+    return application;
+  }
+
+  async getTrainingApplications(): Promise<TrainingApplication[]> {
+    return Array.from(this.trainingApplications.values()).sort(
       (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
     );
   }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, boolean, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, boolean, timestamp } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -19,6 +19,23 @@ export const contactMessages = pgTable("contact_messages", {
 });
 
 
+export const trainingApplications = pgTable("training_applications", {
+  id: serial("id").primaryKey(),
+  firstName: text("first_name").notNull(),
+  lastName: text("last_name").notNull(),
+  dateOfBirth: text("date_of_birth").notNull(),
+  address: text("address").notNull(),
+  phoneNumber: text("phone_number").notNull(),
+  email: text("email").notNull(),
+  employmentStatus: text("employment_status").notNull(),
+  employmentStatusOther: text("employment_status_other"),
+  motivations: text("motivations").notNull(),
+  careerGoals: text("career_goals").notNull(),
+  declarationAccepted: boolean("declaration_accepted").default(false).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+
 
 export const insertUserSchema = createInsertSchema(users).pick({
   username: true,
@@ -30,7 +47,14 @@ export const insertContactMessageSchema = createInsertSchema(contactMessages).om
   createdAt: true,
 });
 
+export const insertTrainingApplicationSchema = createInsertSchema(trainingApplications).omit({
+  id: true,
+  createdAt: true,
+});
+
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type User = typeof users.$inferSelect;
 export type InsertContactMessage = z.infer<typeof insertContactMessageSchema>;
 export type ContactMessage = typeof contactMessages.$inferSelect;
+export type InsertTrainingApplication = z.infer<typeof insertTrainingApplicationSchema>;
+export type TrainingApplication = typeof trainingApplications.$inferSelect;


### PR DESCRIPTION
## Summary
- add a bilingual Learn page with training highlights and a training application form
- extend translations, routing, and sitemap entries for the new training experience
- store submitted applications on the server with validation, anti-spam controls, and Discord notifications

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8a51ad0ac8325870765d05a124790