### PR TITLE
feat: launch student portal workflow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,10 @@ import NotFound from "@/pages/not-found";
 import ServerError from "./pages/ServerError";
 import ErrorTest from "./pages/ErrorTest";
 import { useState } from "react";
+import Learn from "./pages/Learn";
+import StudentLogin from "./pages/StudentLogin";
+import StudentPasswordReset from "./pages/StudentPasswordReset";
+import StudentPortal from "./pages/StudentPortal";
 
 function Router() {
   return (
@@ -29,6 +33,14 @@ function Router() {
         <Route path="/" component={Home} />
         <Route path="/secteurs-activite" component={ActivitySectors} />
         <Route path="/services" component={Services} />
+        <Route path="/learn" component={Learn} />
+        <Route path="/apprendre" component={Learn} />
+        <Route path="/student/login" component={StudentLogin} />
+        <Route path="/etudiant/connexion" component={StudentLogin} />
+        <Route path="/student/change-password" component={StudentPasswordReset} />
+        <Route path="/etudiant/mot-de-passe" component={StudentPasswordReset} />
+        <Route path="/student/portal" component={StudentPortal} />
+        <Route path="/etudiant/portail" component={StudentPortal} />
         <Route path="/contact" component={Contact} />
         <Route path="/public-safety" component={PublicSafety} />
         <Route path="/francophone-services" component={FrancophoneServices} />

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -77,6 +77,12 @@ export const Header = () => {
           <span className="ontario-pride-text hidden md:block whitespace-nowrap">
             {language === 'fr' ? 'Fier de l\'Ontario' : 'Proud of Ontario'}
           </span>
+          <Link
+            href={language === 'fr' ? '/etudiant/connexion' : '/student/login'}
+            className="text-[#f89422] text-xs md:text-sm font-semibold hover:text-white transition-colors"
+          >
+            {t.studentPortal.navLabel}
+          </Link>
           <button
             ref={buttonRef}
             onClick={toggleLanguage}

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -12,7 +12,9 @@ export interface TranslationData {
     home: string;
     divisions: string;
     services: string;
+    learn: string;
     contact: string;
+    studentPortal: string;
   };
   hero: {
     title: string;
@@ -70,6 +72,157 @@ export interface TranslationData {
     ctaTitle: string;
     ctaDescription: string;
     ctaButton: string;
+  };
+  learn: {
+    title: string;
+    subtitle: string;
+    intro: string;
+    highlights: {
+      title: string;
+      description: string;
+    }[];
+    benefits: {
+      title: string;
+      items: string[];
+    };
+    form: {
+      title: string;
+      description: string;
+      personal: {
+        title: string;
+        firstName: string;
+        lastName: string;
+        dateOfBirth: string;
+        address: string;
+        phoneNumber: string;
+        email: string;
+        placeholders: {
+          firstName: string;
+          lastName: string;
+          dateOfBirth: string;
+          address: string;
+          phoneNumber: string;
+          email: string;
+        };
+      };
+      employment: {
+        title: string;
+        description: string;
+        options: {
+          employee: string;
+          jobSeeker: string;
+          student: string;
+          selfEmployed: string;
+          other: string;
+        };
+        otherPlaceholder: string;
+      };
+      motivations: {
+        title: string;
+        motivationsLabel: string;
+        careerGoalsLabel: string;
+        motivationsPlaceholder: string;
+        careerGoalsPlaceholder: string;
+      };
+      declaration: {
+        title: string;
+        text: string;
+        checkbox: string;
+        fullNamePlaceholder: string;
+      };
+      submit: string;
+      successTitle: string;
+      successMessage: string;
+      errors: {
+        required: string;
+        email: string;
+        phone: string;
+        declaration: string;
+        otherRequired: string;
+        motivationsLength: string;
+        careerLength: string;
+        tooFast: string;
+      };
+    };
+  };
+  studentPortal: {
+    navLabel: string;
+    login: {
+      title: string;
+      subtitle: string;
+      cardNumber: string;
+      password: string;
+      submit: string;
+      success: string;
+      hints: string;
+      errors: {
+        missingFields: string;
+        notFound: string;
+        inactive: string;
+        invalidCredentials: string;
+        server: string;
+      };
+    };
+    changePassword: {
+      title: string;
+      subtitle: string;
+      currentPassword: string;
+      newPassword: string;
+      confirmPassword: string;
+      submit: string;
+      success: string;
+      requirements: string[];
+      errors: {
+        missingFields: string;
+        mismatch: string;
+        weakPassword: string;
+        invalidCurrentPassword: string;
+        reused: string;
+        server: string;
+      };
+    };
+    dashboard: {
+      title: string;
+      welcome: string;
+      sections: {
+        studentInfo: string;
+        activeCourses: string;
+        inProgress: string;
+        completedCourses: string;
+        pendingRequests: string;
+        store: string;
+      };
+      infoLabels: {
+        cardNumber: string;
+        email: string;
+        phone: string;
+        address: string;
+      };
+      statusLabels: {
+        active: string;
+        inProgress: string;
+        completed: string;
+        pending: string;
+      };
+      empty: {
+        active: string;
+        inProgress: string;
+        completed: string;
+        pending: string;
+        store: string;
+      };
+      actions: {
+        requestCourse: string;
+        requested: string;
+        refresh: string;
+        changePassword: string;
+      };
+      messages: {
+        requestSuccess: string;
+        unauthorized: string;
+        alreadyRequested: string;
+      };
+    };
   };
   contact: {
     title: string;

--- a/client/src/lib/studentSession.ts
+++ b/client/src/lib/studentSession.ts
@@ -1,0 +1,52 @@
+export interface StudentSessionStudent {
+  id: number;
+  cardNumber: string;
+  firstName: string;
+  lastName: string;
+  requiresPasswordChange: boolean;
+}
+
+export interface StudentSession {
+  token: string;
+  student: StudentSessionStudent;
+}
+
+const STORAGE_KEY = "rg-student-portal-session";
+
+export function getStudentSession(): StudentSession | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    return JSON.parse(raw) as StudentSession;
+  } catch (error) {
+    console.warn("Failed to parse student session from storage", error);
+    return null;
+  }
+}
+
+export function setStudentSession(session: StudentSession): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+}
+
+export function clearStudentSession(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export function updateStudentSessionStudent(update: Partial<StudentSessionStudent>): StudentSession | null {
+  const existing = getStudentSession();
+  if (!existing) {
+    return null;
+  }
+
+  const updated: StudentSession = {
+    ...existing,
+    student: {
+      ...existing.student,
+      ...update,
+    },
+  };
+  setStudentSession(updated);
+  return updated;
+}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -7,7 +7,9 @@
     "home": "Home",
     "divisions": "Activity Sectors",
     "services": "Services",
-    "contact": "Contact"
+    "learn": "Learn",
+    "contact": "Contact",
+    "studentPortal": "Student Portal"
   },
   "hero": {
     "title": "Innovative",
@@ -65,6 +67,176 @@
     "ctaTitle": "Ready to start your project?",
     "ctaDescription": "Let's discuss your needs and discover how our services can transform your organization.",
     "ctaButton": "Get a free consultation"
+  },
+  "learn": {
+    "title": "Professional Training Programs",
+    "subtitle": "Advance your career with bilingual courses tailored for safety and community leaders.",
+    "intro": "Our training division delivers applied learning experiences that combine regulatory knowledge, scenario-based practice, and strategic coaching for individuals ready to elevate their impact.",
+    "highlights": [
+      {
+        "title": "Hands-on scenarios",
+        "description": "Scenario-based workshops that replicate real incidents in public safety, occupational health, and community services."
+      },
+      {
+        "title": "Certified instructors",
+        "description": "Courses delivered by bilingual experts with frontline experience across Canada and recognized accreditations."
+      },
+      {
+        "title": "Career support",
+        "description": "Personalized guidance to align the training path with your professional ambitions and next career steps."
+      }
+    ],
+    "benefits": {
+      "title": "What you will gain",
+      "items": [
+        "Up-to-date competencies that reflect Canadian standards for safety, health, and community programming.",
+        "Coaching to translate classroom learning into immediate workplace impact.",
+        "Access to the Rémi Guillette Group professional network for continued mentorship."
+      ]
+    },
+    "form": {
+      "title": "Training Application Form",
+      "description": "Complete the application below so our admissions team can follow up with you.",
+      "personal": {
+        "title": "Personal Information",
+        "firstName": "First Name",
+        "lastName": "Last Name",
+        "dateOfBirth": "Date of Birth",
+        "address": "Full Address",
+        "phoneNumber": "Phone Number",
+        "email": "Email Address",
+        "placeholders": {
+          "firstName": "Your first name",
+          "lastName": "Your last name",
+          "dateOfBirth": "YYYY-MM-DD",
+          "address": "123 Main Street, City, Province",
+          "phoneNumber": "(123) 456-7890",
+          "email": "your@email.com"
+        }
+      },
+      "employment": {
+        "title": "Current Employment Status",
+        "description": "Current Status *",
+        "options": {
+          "employee": "Employee",
+          "jobSeeker": "Job Seeker",
+          "student": "Student",
+          "selfEmployed": "Self-Employed / Entrepreneur",
+          "other": "Other (please specify)"
+        },
+        "otherPlaceholder": "Please specify your status"
+      },
+      "motivations": {
+        "title": "Motivations and Career Plan",
+        "motivationsLabel": "Why do you want to take this training? What are your motivations? *",
+        "careerGoalsLabel": "What are your professional goals after completing this training? *",
+        "motivationsPlaceholder": "Share what drives you to enrol in this program...",
+        "careerGoalsPlaceholder": "Describe the career path you plan to pursue after the training..."
+      },
+      "declaration": {
+        "title": "Declaration",
+        "text": "I, the undersigned, {{fullName}}, certify that the information provided in this form is accurate and complete.",
+        "checkbox": "I confirm that the information provided is accurate.",
+        "fullNamePlaceholder": "your full name"
+      },
+      "submit": "Submit Application",
+      "successTitle": "Application submitted",
+      "successMessage": "Thank you for applying! Our team will contact you soon.",
+      "errors": {
+        "required": "Please fill in all required fields.",
+        "email": "Please enter a valid email address.",
+        "phone": "Please enter a phone number with at least 10 digits.",
+        "declaration": "You must accept the declaration to submit your application.",
+        "otherRequired": "Please specify your current status.",
+        "motivationsLength": "Please provide at least 20 characters for your motivations.",
+        "careerLength": "Please provide at least 20 characters for your career goals.",
+        "tooFast": "Please take a few moments to complete the form before submitting."
+      }
+    }
+  },
+  "studentPortal": {
+    "navLabel": "Student Portal",
+    "login": {
+      "title": "Student access",
+      "subtitle": "Enter your card number and the temporary password provided by the administration team.",
+      "cardNumber": "Student card number",
+      "password": "Temporary password",
+      "submit": "Sign in",
+      "success": "Login successful. Redirecting to your secure space...",
+      "hints": "Need help? Contact the admissions team to retrieve your credentials.",
+      "errors": {
+        "missingFields": "Please provide both your card number and password.",
+        "notFound": "We were unable to find a student account with that card number.",
+        "inactive": "Your account has not been activated yet. Please contact the administration.",
+        "invalidCredentials": "The credentials provided are invalid. Double-check your temporary password.",
+        "server": "An unexpected error occurred. Please try again later."
+      }
+    },
+    "changePassword": {
+      "title": "Create your permanent password",
+      "subtitle": "For security reasons, you must replace the temporary password with a new one.",
+      "currentPassword": "Current password",
+      "newPassword": "New password",
+      "confirmPassword": "Confirm new password",
+      "submit": "Update password",
+      "success": "Password updated. Welcome to your student space!",
+      "requirements": [
+        "At least 8 characters",
+        "Include one uppercase letter",
+        "Include one number",
+        "Avoid reusing your temporary password"
+      ],
+      "errors": {
+        "missingFields": "All password fields are required.",
+        "mismatch": "The confirmation password must match.",
+        "weakPassword": "Please choose a password with at least 8 characters, one uppercase letter, and one number.",
+        "invalidCurrentPassword": "The current password is incorrect.",
+        "reused": "Choose a password that is different from the current one.",
+        "server": "We could not update your password. Try again later."
+      }
+    },
+    "dashboard": {
+      "title": "Student dashboard",
+      "welcome": "Welcome back, {{name}}!",
+      "sections": {
+        "studentInfo": "Student information",
+        "activeCourses": "Active courses",
+        "inProgress": "Work in progress",
+        "completedCourses": "Completed courses",
+        "pendingRequests": "Pending activations",
+        "store": "Available courses"
+      },
+      "infoLabels": {
+        "cardNumber": "Card number",
+        "email": "Email",
+        "phone": "Phone",
+        "address": "Address"
+      },
+      "statusLabels": {
+        "active": "Active",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "pending": "Pending"
+      },
+      "empty": {
+        "active": "No active courses at the moment.",
+        "inProgress": "Courses in progress will appear here once activated.",
+        "completed": "Completed courses will be archived here.",
+        "pending": "No course activation requests are pending.",
+        "store": "All available courses are already linked to your profile."
+      },
+      "actions": {
+        "requestCourse": "Add to my account",
+        "requested": "Pending activation",
+        "refresh": "Refresh",
+        "changePassword": "Update password"
+      },
+      "messages": {
+        "requestSuccess": "Course request submitted. A teacher will review it shortly.",
+        "unauthorized": "Your session expired. Please sign in again.",
+        "alreadyRequested": "You have already requested this course. Our team is reviewing it."
+      }
+    }
   },
   "contact": {
     "title": "Contact Us",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -7,7 +7,9 @@
     "home": "Accueil",
     "divisions": "Secteurs d'activité",
     "services": "Services",
-    "contact": "Contact"
+    "learn": "Formations",
+    "contact": "Contact",
+    "studentPortal": "Portail étudiant"
   },
   "hero": {
     "title": "Excellence en",
@@ -65,6 +67,176 @@
     "ctaTitle": "Prêt à commencer votre projet?",
     "ctaDescription": "Discutons de vos besoins et découvrons comment nos services peuvent transformer votre organisation.",
     "ctaButton": "Obtenir une consultation gratuite"
+  },
+  "learn": {
+    "title": "Programmes de formation professionnelle",
+    "subtitle": "Faites progresser votre carrière avec des parcours bilingues adaptés aux leaders de la sécurité et des services communautaires.",
+    "intro": "Notre division formation propose des expériences d'apprentissage appliquées qui combinent connaissances réglementaires, mises en situation et accompagnement stratégique pour amplifier votre impact.",
+    "highlights": [
+      {
+        "title": "Scénarios pratiques",
+        "description": "Ateliers basés sur des scénarios reproduisant des situations réelles en sécurité publique, santé et services communautaires."
+      },
+      {
+        "title": "Formateurs certifiés",
+        "description": "Des experts bilingues possédant une expérience terrain à travers le Canada et des accréditations reconnues."
+      },
+      {
+        "title": "Accompagnement de carrière",
+        "description": "Un guidage personnalisé pour aligner la formation sur vos ambitions professionnelles et vos prochaines étapes."
+      }
+    ],
+    "benefits": {
+      "title": "Ce que vous retirerez",
+      "items": [
+        "Des compétences actualisées conformes aux normes canadiennes en sécurité, santé et programmation communautaire.",
+        "Un coaching pour transformer les apprentissages en résultats concrets sur le terrain.",
+        "L'accès au réseau professionnel du Groupe Rémi Guillette pour un mentorat continu."
+      ]
+    },
+    "form": {
+      "title": "Formulaire de demande de formation",
+      "description": "Remplissez la demande ci-dessous afin que notre équipe d'admission puisse vous contacter.",
+      "personal": {
+        "title": "Renseignements personnels",
+        "firstName": "Prénom",
+        "lastName": "Nom",
+        "dateOfBirth": "Date de naissance",
+        "address": "Adresse complète",
+        "phoneNumber": "Numéro de téléphone",
+        "email": "Adresse courriel",
+        "placeholders": {
+          "firstName": "Votre prénom",
+          "lastName": "Votre nom",
+          "dateOfBirth": "AAAA-MM-JJ",
+          "address": "123 rue Principale, Ville, Province",
+          "phoneNumber": "(123) 456-7890",
+          "email": "votre@email.com"
+        }
+      },
+      "employment": {
+        "title": "Statut professionnel actuel",
+        "description": "Statut actuel *",
+        "options": {
+          "employee": "Employé(e)",
+          "jobSeeker": "Chercheur d'emploi",
+          "student": "Étudiant(e)",
+          "selfEmployed": "Travailleur autonome / Entrepreneur",
+          "other": "Autre (veuillez préciser)"
+        },
+        "otherPlaceholder": "Veuillez préciser votre statut"
+      },
+      "motivations": {
+        "title": "Motivations et plan de carrière",
+        "motivationsLabel": "Pourquoi souhaitez-vous suivre cette formation? Quelles sont vos motivations? *",
+        "careerGoalsLabel": "Quels sont vos objectifs professionnels après la formation? *",
+        "motivationsPlaceholder": "Expliquez ce qui vous motive à intégrer ce programme...",
+        "careerGoalsPlaceholder": "Décrivez le parcours professionnel que vous envisagez après la formation..."
+      },
+      "declaration": {
+        "title": "Déclaration",
+        "text": "Je soussigné(e), {{fullName}}, certifie que les renseignements fournis dans ce formulaire sont exacts et complets.",
+        "checkbox": "Je confirme que les renseignements fournis sont exacts.",
+        "fullNamePlaceholder": "vos prénom et nom"
+      },
+      "submit": "Soumettre la demande",
+      "successTitle": "Demande envoyée",
+      "successMessage": "Merci pour votre intérêt! Notre équipe vous contactera prochainement.",
+      "errors": {
+        "required": "Veuillez remplir tous les champs obligatoires.",
+        "email": "Veuillez saisir une adresse courriel valide.",
+        "phone": "Veuillez saisir un numéro de téléphone d'au moins 10 chiffres.",
+        "declaration": "Vous devez accepter la déclaration pour soumettre votre demande.",
+        "otherRequired": "Veuillez préciser votre statut actuel.",
+        "motivationsLength": "Veuillez fournir au moins 20 caractères pour vos motivations.",
+        "careerLength": "Veuillez fournir au moins 20 caractères pour vos objectifs professionnels.",
+        "tooFast": "Prenez quelques instants pour compléter le formulaire avant de l'envoyer."
+      }
+    }
+  },
+  "studentPortal": {
+    "navLabel": "Portail étudiant",
+    "login": {
+      "title": "Accès étudiant",
+      "subtitle": "Entrez votre numéro de carte et le mot de passe temporaire remis par l'administration.",
+      "cardNumber": "Numéro de carte étudiante",
+      "password": "Mot de passe temporaire",
+      "submit": "Se connecter",
+      "success": "Connexion réussie. Redirection vers votre espace sécurisé...",
+      "hints": "Besoin d'aide? Communiquez avec l'équipe des admissions pour récupérer vos accès.",
+      "errors": {
+        "missingFields": "Veuillez indiquer votre numéro de carte et votre mot de passe.",
+        "notFound": "Aucun compte étudiant ne correspond à ce numéro de carte.",
+        "inactive": "Votre compte n'est pas encore activé. Contactez l'administration.",
+        "invalidCredentials": "Les informations fournies sont invalides. Vérifiez votre mot de passe temporaire.",
+        "server": "Une erreur est survenue. Veuillez réessayer plus tard."
+      }
+    },
+    "changePassword": {
+      "title": "Créer votre mot de passe permanent",
+      "subtitle": "Pour des raisons de sécurité, vous devez remplacer le mot de passe temporaire.",
+      "currentPassword": "Mot de passe actuel",
+      "newPassword": "Nouveau mot de passe",
+      "confirmPassword": "Confirmer le nouveau mot de passe",
+      "submit": "Mettre à jour",
+      "success": "Mot de passe mis à jour. Bienvenue dans votre espace étudiant!",
+      "requirements": [
+        "Au moins 8 caractères",
+        "Inclure une lettre majuscule",
+        "Inclure un chiffre",
+        "Ne pas réutiliser le mot de passe temporaire"
+      ],
+      "errors": {
+        "missingFields": "Tous les champs sont requis.",
+        "mismatch": "La confirmation doit être identique.",
+        "weakPassword": "Choisissez un mot de passe d'au moins 8 caractères avec une majuscule et un chiffre.",
+        "invalidCurrentPassword": "Le mot de passe actuel est incorrect.",
+        "reused": "Veuillez choisir un mot de passe différent de l'actuel.",
+        "server": "Impossible de mettre à jour le mot de passe pour l'instant."
+      }
+    },
+    "dashboard": {
+      "title": "Tableau de bord étudiant",
+      "welcome": "Bon retour, {{name}}!",
+      "sections": {
+        "studentInfo": "Informations étudiantes",
+        "activeCourses": "Cours actifs",
+        "inProgress": "Travail en cours",
+        "completedCourses": "Cours complétés",
+        "pendingRequests": "Activations en attente",
+        "store": "Cours disponibles"
+      },
+      "infoLabels": {
+        "cardNumber": "Numéro de carte",
+        "email": "Courriel",
+        "phone": "Téléphone",
+        "address": "Adresse"
+      },
+      "statusLabels": {
+        "active": "Actif",
+        "inProgress": "En cours",
+        "completed": "Terminé",
+        "pending": "En attente"
+      },
+      "empty": {
+        "active": "Aucun cours actif pour le moment.",
+        "inProgress": "Les cours en cours apparaîtront ici dès leur activation.",
+        "completed": "Les cours complétés seront répertoriés ici.",
+        "pending": "Aucune demande d'activation en attente.",
+        "store": "Tous les cours disponibles sont déjà liés à votre profil."
+      },
+      "actions": {
+        "requestCourse": "Ajouter à mon compte",
+        "requested": "Activation en attente",
+        "refresh": "Rafraîchir",
+        "changePassword": "Modifier le mot de passe"
+      },
+      "messages": {
+        "requestSuccess": "Demande envoyée. Un formateur l'analysera sous peu.",
+        "unauthorized": "Votre session a expiré. Veuillez vous reconnecter.",
+        "alreadyRequested": "Vous avez déjà demandé ce cours. Notre équipe l'examine."
+      }
+    }
   },
   "contact": {
     "title": "Contactez-Nous",

--- a/client/src/pages/Learn.tsx
+++ b/client/src/pages/Learn.tsx
@@ -1,0 +1,540 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from '../contexts/TranslationContext';
+import { useToast } from '../hooks/use-toast';
+import { useMutation } from '@tanstack/react-query';
+import { apiRequest } from '../lib/queryClient';
+import { useScrollToTop } from '../hooks/useScrollToTop';
+import { BadgeCheck, CheckCircle, GraduationCap, Rocket } from 'lucide-react';
+
+type FormState = {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  address: string;
+  phoneNumber: string;
+  email: string;
+  employmentStatus: string;
+  employmentStatusOther: string;
+  motivations: string;
+  careerGoals: string;
+  declarationAccepted: boolean;
+};
+
+const initialFormState: FormState = {
+  firstName: '',
+  lastName: '',
+  dateOfBirth: '',
+  address: '',
+  phoneNumber: '',
+  email: '',
+  employmentStatus: '',
+  employmentStatusOther: '',
+  motivations: '',
+  careerGoals: '',
+  declarationAccepted: false,
+};
+
+export default function Learn() {
+  const { t, language } = useTranslation();
+  const { toast } = useToast();
+  useScrollToTop();
+  const submitButtonRef = useRef<HTMLButtonElement>(null);
+  const [formData, setFormData] = useState<FormState>(initialFormState);
+  const [formStartTime] = useState(() => Date.now());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!submitButtonRef.current) return;
+
+    let angle = 0;
+    let animationFrameId: number;
+
+    const rotateGradient = () => {
+      angle = (angle + 1) % 360;
+      if (submitButtonRef.current) {
+        submitButtonRef.current.style.setProperty('--gradient-angle', `${angle}deg`);
+      }
+      animationFrameId = requestAnimationFrame(rotateGradient);
+    };
+
+    rotateGradient();
+
+    return () => {
+      if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId);
+      }
+    };
+  }, []);
+
+  const employmentOptions = useMemo(
+    () => [
+      { value: 'employee', label: t.learn.form.employment.options.employee },
+      { value: 'jobSeeker', label: t.learn.form.employment.options.jobSeeker },
+      { value: 'student', label: t.learn.form.employment.options.student },
+      { value: 'selfEmployed', label: t.learn.form.employment.options.selfEmployed },
+      { value: 'other', label: t.learn.form.employment.options.other },
+    ],
+    [t.learn.form.employment.options]
+  );
+
+  const highlightIcons = useMemo(() => [GraduationCap, BadgeCheck, Rocket], []);
+
+  const errorTitle = language === 'fr' ? 'Erreur' : 'Error';
+
+  const applicationMutation = useMutation({
+    mutationFn: async (data: FormState) => {
+      const submissionData = {
+        ...data,
+        formStartTime: formStartTime.toString(),
+        website: '',
+        url: '',
+        phone_hidden: '',
+      };
+
+      const response = await apiRequest('POST', '/api/training-applications', submissionData);
+      return response.json();
+    },
+    onSuccess: () => {
+      setIsSubmitting(false);
+      toast({
+        title: t.learn.form.successTitle,
+        description: t.learn.form.successMessage,
+      });
+      setFormData({ ...initialFormState });
+    },
+    onError: (error: any) => {
+      setIsSubmitting(false);
+      console.error('Training application error:', error);
+      const fallbackMessage = language === 'fr'
+        ? "Une erreur est survenue lors de l'envoi de votre demande. Veuillez réessayer."
+        : 'An error occurred while submitting your application. Please try again.';
+      const errorMessage = error?.message || fallbackMessage;
+      toast({
+        title: errorTitle,
+        description: errorMessage,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value, type, checked } = event.target;
+
+    if (type === 'checkbox') {
+      setFormData((prev) => ({
+        ...prev,
+        [name]: checked,
+      }));
+      return;
+    }
+
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleEmploymentChange = (value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      employmentStatus: value,
+      employmentStatusOther: value === 'other' ? prev.employmentStatusOther : '',
+    }));
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isSubmitting || applicationMutation.isPending) {
+      return;
+    }
+
+    const timeSinceLoad = Date.now() - formStartTime;
+    if (timeSinceLoad < 3000) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.tooFast,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const requiredFields: (keyof FormState)[] = [
+      'firstName',
+      'lastName',
+      'dateOfBirth',
+      'address',
+      'phoneNumber',
+      'email',
+      'employmentStatus',
+      'motivations',
+      'careerGoals',
+    ];
+
+    const hasEmptyRequired = requiredFields.some((field) => !String(formData[field]).trim());
+    if (hasEmptyRequired) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.required,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (
+      formData.employmentStatus === 'other' &&
+      !formData.employmentStatusOther.trim()
+    ) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.otherRequired,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(formData.email)) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.email,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const phoneDigits = formData.phoneNumber.replace(/\D/g, '');
+    if (phoneDigits.length < 10) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.phone,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (formData.motivations.trim().length < 20) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.motivationsLength,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (formData.careerGoals.trim().length < 20) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.careerLength,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (!formData.declarationAccepted) {
+      toast({
+        title: errorTitle,
+        description: t.learn.form.errors.declaration,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const submission: FormState = {
+      ...formData,
+      address: formData.address.trim(),
+      phoneNumber: formData.phoneNumber.trim(),
+      email: formData.email.trim(),
+      motivations: formData.motivations.trim(),
+      careerGoals: formData.careerGoals.trim(),
+      employmentStatusOther:
+        formData.employmentStatus === 'other'
+          ? formData.employmentStatusOther.trim()
+          : '',
+    };
+
+    applicationMutation.mutate(submission);
+  };
+
+  const fullNameForDeclaration = [formData.firstName.trim(), formData.lastName.trim()]
+    .filter(Boolean)
+    .join(' ') || t.learn.form.declaration.fullNamePlaceholder;
+  const declarationText = t.learn.form.declaration.text.replace('{{fullName}}', fullNameForDeclaration);
+
+  return (
+    <main className="bg-rg-dark-bg min-h-screen w-full py-16 text-white">
+      <div className="container-responsive space-y-16">
+        <header className="text-center space-y-6 max-w-4xl mx-auto">
+          <h1 className="text-4xl md:text-5xl font-bold" style={{ color: '#f89422' }}>
+            {t.learn.title}
+          </h1>
+          <p className="text-xl text-gray-300">{t.learn.subtitle}</p>
+          <p className="text-lg text-gray-300 leading-relaxed">{t.learn.intro}</p>
+        </header>
+
+        <section className="grid gap-6 md:grid-cols-3">
+          {t.learn.highlights.map((highlight, index) => {
+            const Icon = highlightIcons[index % highlightIcons.length];
+            return (
+              <div
+                key={highlight.title}
+                className="bg-rg-card-bg border border-rg-gray rounded-2xl p-6 h-full flex flex-col"
+              >
+                <div className="w-14 h-14 rounded-xl bg-gradient-to-br from-orange-500 to-blue-500 flex items-center justify-center mb-4">
+                  <Icon className="w-7 h-7 text-white" aria-hidden="true" />
+                </div>
+                <h3 className="text-xl font-semibold mb-3" style={{ color: '#f89422' }}>
+                  {highlight.title}
+                </h3>
+                <p className="text-gray-300 leading-relaxed">
+                  {highlight.description}
+                </p>
+              </div>
+            );
+          })}
+        </section>
+
+        <section className="bg-rg-card-bg border border-rg-gray rounded-2xl p-8">
+          <h2 className="text-3xl font-bold mb-6" style={{ color: '#f89422' }}>
+            {t.learn.benefits.title}
+          </h2>
+          <ul className="space-y-4">
+            {t.learn.benefits.items.map((item, index) => (
+              <li key={index} className="flex items-start text-gray-300">
+                <CheckCircle className="w-5 h-5 text-[#f89422] mt-1 mr-3" aria-hidden="true" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="bg-rg-card-bg border border-rg-gray rounded-2xl p-8">
+          <h2 className="text-3xl font-bold mb-4" style={{ color: '#f89422' }}>
+            {t.learn.form.title}
+          </h2>
+          <p className="text-gray-300 mb-8">{t.learn.form.description}</p>
+
+          <form onSubmit={handleSubmit} className="space-y-10">
+            <fieldset className="space-y-6">
+              <legend className="text-2xl font-semibold" style={{ color: '#f89422' }}>
+                {t.learn.form.personal.title}
+              </legend>
+              <div className="grid gap-6 md:grid-cols-2">
+                <div>
+                  <label htmlFor="firstName" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.personal.firstName}
+                  </label>
+                  <input
+                    id="firstName"
+                    name="firstName"
+                    type="text"
+                    value={formData.firstName}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.personal.placeholders.firstName}
+                    autoComplete="given-name"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="lastName" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.personal.lastName}
+                  </label>
+                  <input
+                    id="lastName"
+                    name="lastName"
+                    type="text"
+                    value={formData.lastName}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.personal.placeholders.lastName}
+                    autoComplete="family-name"
+                  />
+                </div>
+              </div>
+              <div className="grid gap-6 md:grid-cols-2">
+                <div>
+                  <label htmlFor="dateOfBirth" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.personal.dateOfBirth}
+                  </label>
+                  <input
+                    id="dateOfBirth"
+                    name="dateOfBirth"
+                    type="date"
+                    value={formData.dateOfBirth}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.personal.placeholders.dateOfBirth}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="phoneNumber" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.personal.phoneNumber}
+                  </label>
+                  <input
+                    id="phoneNumber"
+                    name="phoneNumber"
+                    type="tel"
+                    value={formData.phoneNumber}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.personal.placeholders.phoneNumber}
+                    autoComplete="tel"
+                  />
+                </div>
+              </div>
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="md:col-span-2">
+                  <label htmlFor="address" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.personal.address}
+                  </label>
+                  <input
+                    id="address"
+                    name="address"
+                    type="text"
+                    value={formData.address}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.personal.placeholders.address}
+                    autoComplete="street-address"
+                  />
+                </div>
+                <div className="md:col-span-2">
+                  <label htmlFor="email" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.personal.email}
+                  </label>
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    value={formData.email}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.personal.placeholders.email}
+                    autoComplete="email"
+                  />
+                </div>
+              </div>
+            </fieldset>
+
+            <fieldset className="space-y-6">
+              <legend className="text-2xl font-semibold" style={{ color: '#f89422' }}>
+                {t.learn.form.employment.title}
+              </legend>
+              <p className="text-sm text-gray-400">{t.learn.form.employment.description}</p>
+              <div className="space-y-3">
+                {employmentOptions.map((option) => (
+                  <label
+                    key={option.value}
+                    className={`flex items-center justify-between rounded-lg px-4 py-3 transition-colors border-2 ${
+                      formData.employmentStatus === option.value
+                        ? 'border-[#f89422] bg-black'
+                        : 'border-[#1f2937] bg-black/40 hover:border-[#f89422]/60'
+                    }`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <input
+                        type="radio"
+                        name="employmentStatus"
+                        value={option.value}
+                        checked={formData.employmentStatus === option.value}
+                        onChange={() => handleEmploymentChange(option.value)}
+                        className="h-4 w-4 text-[#f89422] focus:ring-[#f89422]"
+                      />
+                      <span className="text-white">{option.label}</span>
+                    </div>
+                    {formData.employmentStatus === option.value && (
+                      <CheckCircle className="w-5 h-5 text-[#f89422]" aria-hidden="true" />
+                    )}
+                  </label>
+                ))}
+              </div>
+
+              {formData.employmentStatus === 'other' && (
+                <div>
+                  <label htmlFor="employmentStatusOther" className="block text-sm font-medium mb-2 text-gray-300">
+                    {t.learn.form.employment.options.other}
+                  </label>
+                  <input
+                    id="employmentStatusOther"
+                    name="employmentStatusOther"
+                    type="text"
+                    value={formData.employmentStatusOther}
+                    onChange={handleInputChange}
+                    className="w-full px-4 py-3 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent"
+                    placeholder={t.learn.form.employment.otherPlaceholder}
+                  />
+                </div>
+              )}
+            </fieldset>
+
+            <fieldset className="space-y-6">
+              <legend className="text-2xl font-semibold" style={{ color: '#f89422' }}>
+                {t.learn.form.motivations.title}
+              </legend>
+              <div>
+                <label htmlFor="motivations" className="block text-sm font-medium mb-2 text-gray-300">
+                  {t.learn.form.motivations.motivationsLabel}
+                </label>
+                <textarea
+                  id="motivations"
+                  name="motivations"
+                  rows={4}
+                  value={formData.motivations}
+                  onChange={handleInputChange}
+                  className="w-full px-4 py-4 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent resize-none"
+                  placeholder={t.learn.form.motivations.motivationsPlaceholder}
+                />
+              </div>
+              <div>
+                <label htmlFor="careerGoals" className="block text-sm font-medium mb-2 text-gray-300">
+                  {t.learn.form.motivations.careerGoalsLabel}
+                </label>
+                <textarea
+                  id="careerGoals"
+                  name="careerGoals"
+                  rows={4}
+                  value={formData.careerGoals}
+                  onChange={handleInputChange}
+                  className="w-full px-4 py-4 bg-black border-2 border-[#f89422] rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#f89422] focus:border-transparent resize-none"
+                  placeholder={t.learn.form.motivations.careerGoalsPlaceholder}
+                />
+              </div>
+            </fieldset>
+
+            <fieldset className="space-y-4">
+              <legend className="text-2xl font-semibold" style={{ color: '#f89422' }}>
+                {t.learn.form.declaration.title}
+              </legend>
+              <p className="text-gray-300 leading-relaxed">{declarationText}</p>
+              <label className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  name="declarationAccepted"
+                  checked={formData.declarationAccepted}
+                  onChange={handleInputChange}
+                  className="mt-1 h-5 w-5 text-[#f89422] focus:ring-[#f89422]"
+                />
+                <span className="text-gray-300">{t.learn.form.declaration.checkbox}</span>
+              </label>
+            </fieldset>
+
+            <button
+              ref={submitButtonRef}
+              type="submit"
+              disabled={isSubmitting || applicationMutation.isPending}
+              className="border-gradient-button w-full md:w-auto px-8 py-4 text-white font-semibold rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting || applicationMutation.isPending
+                ? language === 'fr'
+                  ? 'Envoi en cours...'
+                  : 'Submitting...'
+                : t.learn.form.submit}
+            </button>
+          </form>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/client/src/pages/StudentLogin.tsx
+++ b/client/src/pages/StudentLogin.tsx
@@ -1,0 +1,140 @@
+import { FormEvent, useEffect, useState } from "react";
+import { useTranslation } from "@/contexts/TranslationContext";
+import { useLocation } from "wouter";
+import { useToast } from "@/hooks/use-toast";
+import { useScrollToTop } from "@/hooks/useScrollToTop";
+import { getStudentSession, setStudentSession } from "@/lib/studentSession";
+
+const StudentLogin = () => {
+  useScrollToTop();
+  const { t, language } = useTranslation();
+  const [, navigate] = useLocation();
+  const { toast } = useToast();
+  const [cardNumber, setCardNumber] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const session = getStudentSession();
+    if (session) {
+      const destination = session.student.requiresPasswordChange
+        ? language === "fr" ? "/etudiant/mot-de-passe" : "/student/change-password"
+        : language === "fr" ? "/etudiant/portail" : "/student/portal";
+      navigate(destination);
+    }
+  }, [language, navigate]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await fetch("/api/student/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cardNumber, password }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        const errors = t.studentPortal.login.errors;
+        const errorMap: Record<string, string> = {
+          missing_fields: errors.missingFields,
+          not_found: errors.notFound,
+          inactive: errors.inactive,
+          invalid_credentials: errors.invalidCredentials,
+          server_error: errors.server,
+        };
+        const mapped = errorMap[data.errorCode as string] || errors.server;
+        setErrorMessage(mapped);
+        return;
+      }
+
+      setStudentSession({ token: data.sessionToken, student: data.student });
+      toast({ title: t.studentPortal.login.title, description: t.studentPortal.login.success });
+
+      const destination = data.student.requiresPasswordChange
+        ? language === "fr" ? "/etudiant/mot-de-passe" : "/student/change-password"
+        : language === "fr" ? "/etudiant/portail" : "/student/portal";
+      navigate(destination);
+    } catch (error) {
+      console.error("Student login failed", error);
+      setErrorMessage(t.studentPortal.login.errors.server);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-black text-gray-100 py-16 px-4">
+      <div className="max-w-lg mx-auto bg-[#0d1117] border border-[#1f2937] rounded-2xl shadow-xl p-8 md:p-10 space-y-8">
+        <div className="space-y-3">
+          <p className="text-sm uppercase tracking-widest text-[#f89422]">
+            {t.studentPortal.navLabel}
+          </p>
+          <h1 className="text-3xl md:text-4xl font-bold text-white">
+            {t.studentPortal.login.title}
+          </h1>
+          <p className="text-gray-300 leading-relaxed">
+            {t.studentPortal.login.subtitle}
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-200" htmlFor="card-number">
+              {t.studentPortal.login.cardNumber}
+            </label>
+            <input
+              id="card-number"
+              type="text"
+              value={cardNumber}
+              onChange={(event) => setCardNumber(event.target.value)}
+              required
+              className="w-full rounded-lg border border-[#1f2937] bg-black px-4 py-3 text-gray-100 focus:outline-none focus:ring-2 focus:ring-[#f89422]"
+              autoComplete="username"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-200" htmlFor="password">
+              {t.studentPortal.login.password}
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+              className="w-full rounded-lg border border-[#1f2937] bg-black px-4 py-3 text-gray-100 focus:outline-none focus:ring-2 focus:ring-[#f89422]"
+              autoComplete="current-password"
+            />
+          </div>
+
+          {errorMessage && (
+            <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+              {errorMessage}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full rounded-lg bg-gradient-to-r from-[#0d6efd] to-[#f89422] px-4 py-3 text-center text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isLoading ? (language === "fr" ? "Connexion..." : "Signing in...") : t.studentPortal.login.submit}
+          </button>
+        </form>
+
+        <p className="text-xs text-gray-400 leading-relaxed">
+          {t.studentPortal.login.hints}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default StudentLogin;

--- a/client/src/pages/StudentPasswordReset.tsx
+++ b/client/src/pages/StudentPasswordReset.tsx
@@ -1,0 +1,199 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useLocation } from "wouter";
+import { useTranslation } from "@/contexts/TranslationContext";
+import { useScrollToTop } from "@/hooks/useScrollToTop";
+import { useToast } from "@/hooks/use-toast";
+import {
+  getStudentSession,
+  setStudentSession,
+  clearStudentSession,
+  updateStudentSessionStudent,
+} from "@/lib/studentSession";
+
+const StudentPasswordReset = () => {
+  useScrollToTop();
+  const { t, language } = useTranslation();
+  const [, navigate] = useLocation();
+  const { toast } = useToast();
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const session = useMemo(() => getStudentSession(), []);
+
+  useEffect(() => {
+    if (!session) {
+      navigate(language === "fr" ? "/etudiant/connexion" : "/student/login");
+      return;
+    }
+  }, [language, navigate, session]);
+
+  const validatePasswordStrength = (password: string) => {
+    const hasUppercase = /[A-ZÀÂÄÇÉÈÊËÎÏÔÖÙÛÜŸ]/.test(password);
+    const hasNumber = /\d/.test(password);
+    return password.length >= 8 && hasUppercase && hasNumber;
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!session) {
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    if (!validatePasswordStrength(newPassword)) {
+      setErrorMessage(t.studentPortal.changePassword.errors.weakPassword);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const response = await fetch("/api/student/change-password", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.token}`,
+        },
+        body: JSON.stringify({ currentPassword, newPassword, confirmPassword }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        const errors = t.studentPortal.changePassword.errors;
+        const errorMap: Record<string, string> = {
+          missing_fields: errors.missingFields,
+          mismatch: errors.mismatch,
+          weak_password: errors.weakPassword,
+          invalid_current_password: errors.invalidCurrentPassword,
+          password_reused: errors.reused,
+          update_failed: errors.server,
+          unauthorized: t.studentPortal.dashboard.messages.unauthorized,
+        };
+        const message = errorMap[data.errorCode as string] || errors.server;
+
+        if (data.errorCode === "unauthorized") {
+          clearStudentSession();
+          navigate(language === "fr" ? "/etudiant/connexion" : "/student/login");
+        }
+
+        setErrorMessage(message);
+        return;
+      }
+
+      const updatedSession = {
+        token: data.sessionToken,
+        student: data.student,
+      };
+      setStudentSession(updatedSession);
+      updateStudentSessionStudent({ requiresPasswordChange: false });
+
+      toast({
+        title: t.studentPortal.changePassword.title,
+        description: t.studentPortal.changePassword.success,
+      });
+
+      navigate(language === "fr" ? "/etudiant/portail" : "/student/portal");
+    } catch (error) {
+      console.error("Failed to update student password", error);
+      setErrorMessage(t.studentPortal.changePassword.errors.server);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-black text-gray-100 py-16 px-4">
+      <div className="max-w-2xl mx-auto bg-[#0d1117] border border-[#1f2937] rounded-2xl shadow-xl p-8 md:p-12 space-y-8">
+        <div className="space-y-3">
+          <p className="text-sm uppercase tracking-widest text-[#f89422]">
+            {t.studentPortal.navLabel}
+          </p>
+          <h1 className="text-3xl md:text-4xl font-bold text-white">
+            {t.studentPortal.changePassword.title}
+          </h1>
+          <p className="text-gray-300 leading-relaxed">
+            {t.studentPortal.changePassword.subtitle}
+          </p>
+        </div>
+
+        <div className="rounded-xl border border-[#1f2937] bg-black/60 p-6">
+          <h2 className="text-sm font-semibold text-[#f89422] uppercase tracking-wider mb-3">
+            {language === "fr" ? "Exigences" : "Requirements"}
+          </h2>
+          <ul className="list-disc list-inside space-y-1 text-sm text-gray-300">
+            {t.studentPortal.changePassword.requirements.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-200" htmlFor="current-password">
+              {t.studentPortal.changePassword.currentPassword}
+            </label>
+            <input
+              id="current-password"
+              type="password"
+              value={currentPassword}
+              onChange={(event) => setCurrentPassword(event.target.value)}
+              required
+              className="w-full rounded-lg border border-[#1f2937] bg-black px-4 py-3 text-gray-100 focus:outline-none focus:ring-2 focus:ring-[#f89422]"
+              autoComplete="current-password"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-200" htmlFor="new-password">
+              {t.studentPortal.changePassword.newPassword}
+            </label>
+            <input
+              id="new-password"
+              type="password"
+              value={newPassword}
+              onChange={(event) => setNewPassword(event.target.value)}
+              required
+              className="w-full rounded-lg border border-[#1f2937] bg-black px-4 py-3 text-gray-100 focus:outline-none focus:ring-2 focus:ring-[#f89422]"
+              autoComplete="new-password"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-200" htmlFor="confirm-password">
+              {t.studentPortal.changePassword.confirmPassword}
+            </label>
+            <input
+              id="confirm-password"
+              type="password"
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              required
+              className="w-full rounded-lg border border-[#1f2937] bg-black px-4 py-3 text-gray-100 focus:outline-none focus:ring-2 focus:ring-[#f89422]"
+              autoComplete="new-password"
+            />
+          </div>
+
+          {errorMessage && (
+            <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+              {errorMessage}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full rounded-lg bg-gradient-to-r from-[#0d6efd] to-[#f89422] px-4 py-3 text-center text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isLoading ? (language === "fr" ? "Mise à jour..." : "Updating...") : t.studentPortal.changePassword.submit}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default StudentPasswordReset;

--- a/client/src/pages/StudentPortal.tsx
+++ b/client/src/pages/StudentPortal.tsx
@@ -1,0 +1,440 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useLocation } from "wouter";
+import { useTranslation } from "@/contexts/TranslationContext";
+import { useScrollToTop } from "@/hooks/useScrollToTop";
+import { useToast } from "@/hooks/use-toast";
+import {
+  clearStudentSession,
+  getStudentSession,
+  StudentSession,
+} from "@/lib/studentSession";
+import type {
+  StudentCourseSummary,
+  StudentDashboardData,
+  StudentCourseRequestSummary,
+} from "@/types/studentPortal";
+
+const StudentPortal = () => {
+  useScrollToTop();
+  const { t, language } = useTranslation();
+  const [, navigate] = useLocation();
+  const { toast } = useToast();
+  const [session, setSession] = useState<StudentSession | null>(() => getStudentSession());
+  const [dashboard, setDashboard] = useState<StudentDashboardData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const loginPath = useMemo(
+    () => (language === "fr" ? "/etudiant/connexion" : "/student/login"),
+    [language],
+  );
+
+  const changePasswordPath = useMemo(
+    () => (language === "fr" ? "/etudiant/mot-de-passe" : "/student/change-password"),
+    [language],
+  );
+
+  const handleUnauthorized = useCallback(() => {
+    clearStudentSession();
+    setSession(null);
+    setDashboard(null);
+    toast({
+      title: t.studentPortal.navLabel,
+      description: t.studentPortal.dashboard.messages.unauthorized,
+      variant: "destructive",
+    });
+    navigate(loginPath);
+  }, [loginPath, navigate, t.studentPortal.dashboard.messages.unauthorized, t.studentPortal.navLabel, toast]);
+
+  const formatCurrency = useCallback(
+    (priceCents: number) =>
+      new Intl.NumberFormat(language === "fr" ? "fr-CA" : "en-CA", {
+        style: "currency",
+        currency: "CAD",
+      }).format(priceCents / 100),
+    [language],
+  );
+
+  const getStatusLabel = useCallback(
+    (status: string) => {
+      const labels = t.studentPortal.dashboard.statusLabels;
+      switch (status) {
+        case "in-progress":
+          return labels.inProgress;
+        case "completed":
+          return labels.completed;
+        case "pending":
+          return labels.pending;
+        default:
+          return labels.active;
+      }
+    },
+    [t.studentPortal.dashboard.statusLabels],
+  );
+
+  const fetchDashboard = useCallback(async () => {
+    if (!session) {
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await fetch("/api/student/dashboard", {
+        headers: {
+          Authorization: `Bearer ${session.token}`,
+        },
+      });
+
+      if (response.status === 401) {
+        handleUnauthorized();
+        return;
+      }
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        setErrorMessage(data.error ?? t.studentPortal.login.errors.server);
+        return;
+      }
+
+      setDashboard(data.data);
+    } catch (error) {
+      console.error("Failed to load student dashboard", error);
+      setErrorMessage(t.studentPortal.login.errors.server);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [handleUnauthorized, session, t.studentPortal.login.errors.server]);
+
+  useEffect(() => {
+    if (!session) {
+      navigate(loginPath);
+      return;
+    }
+    fetchDashboard();
+  }, [fetchDashboard, loginPath, navigate, session]);
+
+  const handleRequestCourse = useCallback(
+    async (courseId: number) => {
+      if (!session) {
+        return;
+      }
+
+      try {
+        const response = await fetch("/api/student/store/request", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${session.token}`,
+          },
+          body: JSON.stringify({ courseId }),
+        });
+
+        const data = await response.json();
+
+        if (response.status === 401) {
+          handleUnauthorized();
+          return;
+        }
+
+        if (!response.ok) {
+          if (data.errorCode === "course_already_enrolled") {
+            toast({
+              title: t.studentPortal.dashboard.sections.pendingRequests,
+              description: t.studentPortal.dashboard.messages.alreadyRequested,
+            });
+            return;
+          }
+
+          setErrorMessage(data.error ?? t.studentPortal.login.errors.server);
+          return;
+        }
+
+        if (data.dashboard) {
+          setDashboard(data.dashboard);
+        }
+
+        toast({
+          title: t.studentPortal.dashboard.sections.pendingRequests,
+          description: t.studentPortal.dashboard.messages.requestSuccess,
+        });
+      } catch (error) {
+        console.error("Failed to request student course", error);
+        setErrorMessage(t.studentPortal.login.errors.server);
+      }
+    },
+    [handleUnauthorized, session, t.studentPortal.dashboard.messages.alreadyRequested, t.studentPortal.dashboard.messages.requestSuccess, t.studentPortal.dashboard.sections.pendingRequests, t.studentPortal.login.errors.server, toast],
+  );
+
+  if (!session) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-black text-gray-100 py-12 px-4">
+      <div className="max-w-6xl mx-auto space-y-10">
+        <header className="flex flex-col gap-4 rounded-2xl border border-[#1f2937] bg-[#0d1117] p-6 md:p-8 shadow-xl">
+          <div className="flex flex-col gap-2">
+            <p className="text-sm uppercase tracking-widest text-[#f89422]">
+              {t.studentPortal.dashboard.title}
+            </p>
+            <h1 className="text-3xl md:text-4xl font-bold text-white">
+              {dashboard
+                ? t.studentPortal.dashboard.welcome.replace(
+                    "{{name}}",
+                    `${dashboard.student.firstName} ${dashboard.student.lastName}`,
+                  )
+                : t.studentPortal.dashboard.title}
+            </h1>
+            <p className="text-sm text-gray-300 max-w-2xl">
+              {t.studentPortal.login.hints}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              onClick={() => navigate(changePasswordPath)}
+              className="rounded-lg border border-[#f89422]/60 px-4 py-2 text-sm font-semibold text-[#f89422] transition-colors hover:bg-[#f89422]/10"
+            >
+              {t.studentPortal.dashboard.actions.changePassword}
+            </button>
+            <button
+              onClick={fetchDashboard}
+              className="rounded-lg bg-gradient-to-r from-[#0d6efd] to-[#f89422] px-4 py-2 text-sm font-semibold text-white hover:opacity-90 transition-opacity"
+            >
+              {t.studentPortal.dashboard.actions.refresh}
+            </button>
+          </div>
+        </header>
+
+        {errorMessage && (
+          <div className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-4 text-sm text-red-200">
+            {errorMessage}
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="rounded-xl border border-[#1f2937] bg-[#0d1117] p-10 text-center text-gray-300">
+            {language === "fr" ? "Chargement du portail étudiant..." : "Loading student portal..."}
+          </div>
+        ) : (
+          <div className="space-y-10">
+            {dashboard && (
+              <>
+                <section className="rounded-2xl border border-[#1f2937] bg-[#0d1117] p-6 md:p-8">
+                  <h2 className="text-2xl font-semibold text-white mb-6">
+                    {t.studentPortal.dashboard.sections.studentInfo}
+                  </h2>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-200">
+                    <div>
+                      <p className="uppercase text-xs tracking-widest text-[#f89422]">
+                        {t.studentPortal.dashboard.infoLabels.cardNumber}
+                      </p>
+                      <p className="mt-1 text-lg font-semibold text-white">
+                        {dashboard.student.cardNumber}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="uppercase text-xs tracking-widest text-[#f89422]">
+                        {t.studentPortal.dashboard.infoLabels.email}
+                      </p>
+                      <p className="mt-1 text-lg font-semibold text-white">
+                        {dashboard.student.email}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="uppercase text-xs tracking-widest text-[#f89422]">
+                        {t.studentPortal.dashboard.infoLabels.phone}
+                      </p>
+                      <p className="mt-1 text-lg font-semibold text-white">
+                        {dashboard.student.phoneNumber || (language === "fr" ? "Non fourni" : "Not provided")}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="uppercase text-xs tracking-widest text-[#f89422]">
+                        {t.studentPortal.dashboard.infoLabels.address}
+                      </p>
+                      <p className="mt-1 text-lg font-semibold text-white">
+                        {dashboard.student.address || (language === "fr" ? "Non fournie" : "Not provided")}
+                      </p>
+                    </div>
+                  </div>
+                </section>
+
+                <section className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <CourseSection
+                    title={t.studentPortal.dashboard.sections.activeCourses}
+                    emptyMessage={t.studentPortal.dashboard.empty.active}
+                    courses={dashboard.activeCourses}
+                    getStatusLabel={getStatusLabel}
+                    formatCurrency={formatCurrency}
+                  />
+                  <CourseSection
+                    title={t.studentPortal.dashboard.sections.inProgress}
+                    emptyMessage={t.studentPortal.dashboard.empty.inProgress}
+                    courses={dashboard.inProgressCourses}
+                    getStatusLabel={getStatusLabel}
+                    formatCurrency={formatCurrency}
+                  />
+                  <CourseSection
+                    title={t.studentPortal.dashboard.sections.completedCourses}
+                    emptyMessage={t.studentPortal.dashboard.empty.completed}
+                    courses={dashboard.completedCourses}
+                    getStatusLabel={getStatusLabel}
+                    formatCurrency={formatCurrency}
+                  />
+                  <RequestSection
+                    title={t.studentPortal.dashboard.sections.pendingRequests}
+                    emptyMessage={t.studentPortal.dashboard.empty.pending}
+                    requests={dashboard.pendingRequests}
+                    formatCurrency={formatCurrency}
+                    language={language}
+                    getStatusLabel={getStatusLabel}
+                  />
+                </section>
+
+                <section className="rounded-2xl border border-[#1f2937] bg-[#0d1117] p-6 md:p-8">
+                  <h2 className="text-2xl font-semibold text-white mb-6">
+                    {t.studentPortal.dashboard.sections.store}
+                  </h2>
+                  {dashboard.store.length === 0 ? (
+                    <p className="text-sm text-gray-300">
+                      {t.studentPortal.dashboard.empty.store}
+                    </p>
+                  ) : (
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      {dashboard.store.map((course) => (
+                        <div
+                          key={course.id}
+                          className="flex h-full flex-col justify-between rounded-xl border border-[#1f2937] bg-black/60 p-6"
+                        >
+                          <div className="space-y-3">
+                            <div className="flex items-center justify-between">
+                              <h3 className="text-xl font-semibold text-white">
+                                {course.title}
+                              </h3>
+                              <span className="rounded-full bg-[#f89422]/20 px-3 py-1 text-sm font-semibold text-[#f89422]">
+                                {formatCurrency(course.priceCents)}
+                              </span>
+                            </div>
+                            <p className="text-sm text-gray-300">
+                              {course.description}
+                            </p>
+                          </div>
+                          <button
+                            onClick={() => handleRequestCourse(course.id)}
+                            className="mt-6 w-full rounded-lg bg-gradient-to-r from-[#0d6efd] to-[#f89422] px-4 py-2 text-sm font-semibold text-white hover:opacity-90 transition-opacity"
+                          >
+                            {t.studentPortal.dashboard.actions.requestCourse}
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </section>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface CourseSectionProps {
+  title: string;
+  emptyMessage: string;
+  courses: StudentCourseSummary[];
+  getStatusLabel: (status: string) => string;
+  formatCurrency: (value: number) => string;
+}
+
+const CourseSection = ({ title, emptyMessage, courses, getStatusLabel, formatCurrency }: CourseSectionProps) => (
+  <div className="rounded-2xl border border-[#1f2937] bg-[#0d1117] p-6 md:p-8 space-y-4">
+    <h2 className="text-2xl font-semibold text-white">{title}</h2>
+    {courses.length === 0 ? (
+      <p className="text-sm text-gray-300">{emptyMessage}</p>
+    ) : (
+      <div className="space-y-4">
+        {courses.map((course) => (
+          <div key={course.id} className="rounded-xl border border-[#1f2937] bg-black/60 p-5 space-y-3">
+            <div className="flex items-start justify-between">
+              <div>
+                <h3 className="text-xl font-semibold text-white">{course.title}</h3>
+                <p className="text-sm text-gray-300 mt-1">{course.description}</p>
+              </div>
+              <div className="text-right">
+                <span className="inline-block rounded-full bg-[#f89422]/20 px-3 py-1 text-xs font-semibold text-[#f89422]">
+                  {getStatusLabel(course.status)}
+                </span>
+                <p className="mt-2 text-sm text-gray-400">{formatCurrency(course.priceCents)}</p>
+              </div>
+            </div>
+            <div className="h-2 w-full rounded-full bg-[#1f2937]">
+              <div
+                className="h-2 rounded-full bg-gradient-to-r from-[#0d6efd] to-[#f89422]"
+                style={{ width: `${Math.min(course.progress, 100)}%` }}
+              ></div>
+            </div>
+            <p className="text-xs text-gray-400">
+              {new Date(course.updatedAt).toLocaleString(undefined, {
+                dateStyle: "medium",
+                timeStyle: "short",
+              })}
+            </p>
+          </div>
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+interface RequestSectionProps {
+  title: string;
+  emptyMessage: string;
+  requests: StudentCourseRequestSummary[];
+  formatCurrency: (value: number) => string;
+  language: string;
+  getStatusLabel: (status: string) => string;
+}
+
+const RequestSection = ({
+  title,
+  emptyMessage,
+  requests,
+  formatCurrency,
+  language,
+  getStatusLabel,
+}: RequestSectionProps) => (
+  <div className="rounded-2xl border border-[#1f2937] bg-[#0d1117] p-6 md:p-8 space-y-4">
+    <h2 className="text-2xl font-semibold text-white">{title}</h2>
+    {requests.length === 0 ? (
+      <p className="text-sm text-gray-300">{emptyMessage}</p>
+    ) : (
+      <div className="space-y-4">
+        {requests.map((request) => (
+          <div key={request.id} className="rounded-xl border border-[#1f2937] bg-black/60 p-5 space-y-3">
+            <div className="flex items-start justify-between">
+              <div>
+                <h3 className="text-xl font-semibold text-white">{request.courseTitle}</h3>
+                <p className="text-sm text-gray-300 mt-1">{formatCurrency(request.priceCents)}</p>
+              </div>
+              <span className="inline-block rounded-full bg-[#f89422]/20 px-3 py-1 text-xs font-semibold text-[#f89422]">
+                {getStatusLabel(request.status)}
+              </span>
+            </div>
+            <p className="text-xs text-gray-400">
+              {new Date(request.createdAt).toLocaleString(language === "fr" ? "fr-CA" : "en-CA", {
+                dateStyle: "medium",
+                timeStyle: "short",
+              })}
+            </p>
+          </div>
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+export default StudentPortal;

--- a/client/src/types/studentPortal.ts
+++ b/client/src/types/studentPortal.ts
@@ -1,0 +1,46 @@
+export interface StudentProfile {
+  id: number;
+  cardNumber: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string | null;
+  address: string | null;
+}
+
+export interface StudentCourseSummary {
+  id: number;
+  courseId: number;
+  title: string;
+  description: string;
+  status: string;
+  progress: number;
+  priceCents: number;
+  updatedAt: string;
+}
+
+export interface StudentCourseRequestSummary {
+  id: number;
+  courseId: number;
+  courseTitle: string;
+  priceCents: number;
+  status: string;
+  createdAt: string;
+}
+
+export interface StudentDashboardData {
+  student: StudentProfile;
+  activeCourses: StudentCourseSummary[];
+  inProgressCourses: StudentCourseSummary[];
+  completedCourses: StudentCourseSummary[];
+  pendingRequests: StudentCourseRequestSummary[];
+  store: Array<{
+    id: number;
+    slug: string;
+    title: string;
+    description: string;
+    priceCents: number;
+    isActive: boolean;
+    createdAt: string;
+  }>;
+}

--- a/server/neondb.ts
+++ b/server/neondb.ts
@@ -1,0 +1,70 @@
+import { drizzle } from "drizzle-orm/neon-http";
+import { neon } from "@neondatabase/serverless";
+import {
+  studentAccounts,
+  studentCourses,
+  studentEnrollments,
+  studentCourseRequests,
+} from "@shared/schema";
+
+let cachedDb: ReturnType<typeof drizzle> | null = null;
+
+export interface NeonStatus {
+  connected: boolean;
+  message: string;
+}
+
+export function getNeonDb() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.warn("Neon database URL is not configured. Student portal is operating in memory only.");
+    return null;
+  }
+
+  if (cachedDb) {
+    return cachedDb;
+  }
+
+  const sql = neon(connectionString);
+  cachedDb = drizzle(sql);
+  return cachedDb;
+}
+
+export async function getNeonStatus(): Promise<NeonStatus> {
+  try {
+    const db = getNeonDb();
+    if (!db) {
+      return {
+        connected: false,
+        message: "DATABASE_URL is not set; Neon connection deferred.",
+      };
+    }
+
+    // Perform a lightweight query to validate connectivity.
+    await db.execute("select 1");
+    return {
+      connected: true,
+      message: "Neon connection successful.",
+    };
+  } catch (error) {
+    console.error("Neon status check failed:", error);
+    return {
+      connected: false,
+      message: error instanceof Error ? error.message : "Unknown Neon error",
+    };
+  }
+}
+
+export async function ensureStudentPortalTables(): Promise<void> {
+  const db = getNeonDb();
+  if (!db) {
+    return;
+  }
+
+  // These calls ensure that Drizzle is aware of the tables when migrations are executed.
+  // The actual schema deployment should be handled via `drizzle-kit push` when DATABASE_URL is configured.
+  await db.select().from(studentAccounts).limit(1).execute().catch(() => undefined);
+  await db.select().from(studentCourses).limit(1).execute().catch(() => undefined);
+  await db.select().from(studentEnrollments).limit(1).execute().catch(() => undefined);
+  await db.select().from(studentCourseRequests).limit(1).execute().catch(() => undefined);
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,12 +1,76 @@
-import type { Express } from "express";
+import type { Express, Request } from "express";
 import { createServer, type Server } from "http";
-import { storage } from "./storage";
+import { storage, hashPassword } from "./storage";
+import { randomBytes } from "crypto";
 import { z } from "zod";
-import { insertContactMessageSchema, type InsertContactMessage } from "@shared/schema";
+import { ensureStudentPortalTables } from "./neondb";
+import {
+  insertContactMessageSchema,
+  insertTrainingApplicationSchema,
+  type InsertContactMessage,
+  type InsertTrainingApplication
+} from "@shared/schema";
 
 // Enhanced anti-spam and flood protection
 const submissionTracker = new Map<string, number[]>();
 const shortTermTracker = new Map<string, number[]>(); // For short-term flood protection
+const studentSessions = new Map<string, { studentId: number; createdAt: number }>();
+
+const STUDENT_SESSION_DURATION_MS = 1000 * 60 * 60 * 8; // 8 hours
+
+function createStudentSessionToken(studentId: number): string {
+  // Remove any existing sessions for this student to keep only the newest token active
+  for (const [token, session] of studentSessions.entries()) {
+    if (session.studentId === studentId) {
+      studentSessions.delete(token);
+    }
+  }
+
+  const token = randomBytes(32).toString("hex");
+  studentSessions.set(token, { studentId, createdAt: Date.now() });
+  return token;
+}
+
+function getStudentIdFromRequest(req: Request): number | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) {
+    return null;
+  }
+
+  const [scheme, token] = authHeader.split(" ");
+  if (!token || scheme.toLowerCase() !== "bearer") {
+    return null;
+  }
+
+  const session = studentSessions.get(token);
+  if (!session) {
+    return null;
+  }
+
+  const age = Date.now() - session.createdAt;
+  if (age > STUDENT_SESSION_DURATION_MS) {
+    studentSessions.delete(token);
+    return null;
+  }
+
+  // Refresh session timestamp on use
+  session.createdAt = Date.now();
+  studentSessions.set(token, session);
+  return session.studentId;
+}
+
+function scheduleSessionCleanup() {
+  setInterval(() => {
+    const now = Date.now();
+    for (const [token, session] of studentSessions.entries()) {
+      if (now - session.createdAt > STUDENT_SESSION_DURATION_MS) {
+        studentSessions.delete(token);
+      }
+    }
+  }, STUDENT_SESSION_DURATION_MS).unref?.();
+}
+
+scheduleSessionCleanup();
 
 function isSpamSubmission(ip: string): boolean {
   const now = Date.now();
@@ -64,30 +128,51 @@ function validateFormContent(data: any): boolean {
   // Basic spam content detection
   const spamKeywords = ['viagra', 'casino', 'lottery', 'winner', 'urgent', 'click here', 'free money'];
   const text = `${data.firstName} ${data.lastName} ${data.email} ${data.message}`.toLowerCase();
-  
+
   // Check for spam keywords
   if (spamKeywords.some(keyword => text.includes(keyword))) {
     return false;
   }
-  
+
   // Check for excessive links
   const linkCount = (data.message.match(/https?:\/\//g) || []).length;
   if (linkCount > 2) {
     return false;
   }
-  
+
   // Check message length (too short or too long)
   if (data.message.length < 10 || data.message.length > 2000) {
     return false;
   }
-  
+
+  return true;
+}
+
+function validateApplicationContent(data: InsertTrainingApplication): boolean {
+  const spamKeywords = ['viagra', 'casino', 'lottery', 'winner', 'urgent', 'click here', 'free money'];
+  const text = `${data.firstName} ${data.lastName} ${data.email} ${data.motivations} ${data.careerGoals}`.toLowerCase();
+
+  if (spamKeywords.some(keyword => text.includes(keyword))) {
+    return false;
+  }
+
+  const linkCount = ((data.motivations.match(/https?:\/\//g) || []).length) +
+    ((data.careerGoals.match(/https?:\/\//g) || []).length);
+  if (linkCount > 2) {
+    return false;
+  }
+
+  if (data.motivations.length < 20 || data.careerGoals.length < 20) {
+    return false;
+  }
+
   return true;
 }
 
 // Discord webhook function
 async function sendToDiscordWebhook(contactData: InsertContactMessage) {
   const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
-  
+
   if (!webhookUrl) {
     console.warn("Discord webhook URL not configured, skipping Discord notification");
     return;
@@ -158,7 +243,102 @@ async function sendToDiscordWebhook(contactData: InsertContactMessage) {
   }
 }
 
+async function sendTrainingApplicationToDiscord(applicationData: InsertTrainingApplication) {
+  const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+
+  if (!webhookUrl) {
+    console.warn("Discord webhook URL not configured, skipping training application notification");
+    return;
+  }
+
+  try {
+    const statusLabel = applicationData.employmentStatus === 'other'
+      ? `Autre: ${applicationData.employmentStatusOther || 'Non précisé'}`
+      : applicationData.employmentStatus;
+
+    const embed = {
+      title: "🎓 Nouvelle demande de formation",
+      color: 0x0d6efd,
+      fields: [
+        {
+          name: "👤 Candidat",
+          value: `${applicationData.firstName} ${applicationData.lastName}`,
+          inline: true
+        },
+        {
+          name: "📧 Email",
+          value: applicationData.email,
+          inline: true
+        },
+        {
+          name: "📞 Téléphone",
+          value: applicationData.phoneNumber,
+          inline: true
+        },
+        {
+          name: "🎂 Date de naissance",
+          value: applicationData.dateOfBirth,
+          inline: true
+        },
+        {
+          name: "🏠 Adresse",
+          value: applicationData.address,
+          inline: false
+        },
+        {
+          name: "💼 Statut actuel",
+          value: statusLabel,
+          inline: true
+        },
+        {
+          name: "🎯 Motivations",
+          value: applicationData.motivations.length > 1024
+            ? `${applicationData.motivations.substring(0, 1021)}...`
+            : applicationData.motivations,
+          inline: false
+        },
+        {
+          name: "🚀 Objectifs professionnels",
+          value: applicationData.careerGoals.length > 1024
+            ? `${applicationData.careerGoals.substring(0, 1021)}...`
+            : applicationData.careerGoals,
+          inline: false
+        }
+      ],
+      timestamp: new Date().toISOString(),
+      footer: {
+        text: "Rémi Guillette Groupe - Demande de formation"
+      }
+    };
+
+    const payload = {
+      content: "📥 **Nouvelle demande de formation reçue**",
+      embeds: [embed]
+    };
+
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      throw new Error(`Discord webhook failed: ${response.status} ${response.statusText}`);
+    }
+
+    console.log("Successfully sent training application to Discord");
+  } catch (error) {
+    console.error("Failed to send training application to Discord:", error);
+  }
+}
+
 export async function registerRoutes(app: Express): Promise<Server> {
+
+  ensureStudentPortalTables().catch((error) => {
+    console.warn("Unable to verify Neon student tables:", error);
+  });
 
   // Dynamic sitemap generation
   app.get("/sitemap.xml", (req, res) => {
@@ -174,10 +354,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
       { path: '/divisions', priority: '0.8', changefreq: 'monthly' },
       { path: '/services', priority: '0.8', changefreq: 'monthly' },
       { path: '/contact', priority: '0.7', changefreq: 'monthly' },
+      { path: '/learn', priority: '0.7', changefreq: 'monthly' },
+      { path: '/apprendre', priority: '0.7', changefreq: 'monthly' },
       { path: '/public-safety', priority: '0.7', changefreq: 'monthly' },
       { path: '/francophone-services', priority: '0.7', changefreq: 'monthly' },
       { path: '/health-safety', priority: '0.7', changefreq: 'monthly' },
       { path: '/animal-first-aid', priority: '0.7', changefreq: 'monthly' },
+      { path: '/student/login', priority: '0.6', changefreq: 'monthly' },
+      { path: '/etudiant/connexion', priority: '0.6', changefreq: 'monthly' },
+      { path: '/student/change-password', priority: '0.5', changefreq: 'monthly' },
+      { path: '/etudiant/mot-de-passe', priority: '0.5', changefreq: 'monthly' },
+      { path: '/student/portal', priority: '0.6', changefreq: 'weekly' },
+      { path: '/etudiant/portail', priority: '0.6', changefreq: 'weekly' },
       { path: '/privacy-policy', priority: '0.3', changefreq: 'yearly' },
       { path: '/politique-confidentialite', priority: '0.3', changefreq: 'yearly' }
     ];
@@ -256,7 +444,405 @@ Sitemap: ${baseUrl}/sitemap.xml`;
     res.json({ status: "healthy", timestamp: new Date().toISOString() });
   });
 
+  app.post("/api/student/login", async (req, res) => {
+    try {
+      const { cardNumber, password } = req.body ?? {};
+
+      if (!cardNumber || !password) {
+        return res.status(400).json({
+          success: false,
+          error: "Card number and password are required.",
+          errorCode: "missing_fields",
+        });
+      }
+
+      const student = await storage.getStudentByCardNumber(String(cardNumber));
+      if (!student) {
+        return res.status(401).json({
+          success: false,
+          error: "Unable to find a matching student account.",
+          errorCode: "not_found",
+        });
+      }
+
+      if (!student.isActive) {
+        return res.status(403).json({
+          success: false,
+          error: "This account has not been activated yet.",
+          errorCode: "inactive",
+        });
+      }
+
+      const hashedInput = hashPassword(String(password));
+      const expectedHash =
+        student.requiresPasswordChange || !student.passwordHash
+          ? student.temporaryPasswordHash
+          : student.passwordHash;
+
+      if (expectedHash !== hashedInput) {
+        return res.status(401).json({
+          success: false,
+          error: "The credentials provided are invalid.",
+          errorCode: "invalid_credentials",
+        });
+      }
+
+      const sessionToken = createStudentSessionToken(student.id);
+
+      res.json({
+        success: true,
+        sessionToken,
+        student: {
+          id: student.id,
+          cardNumber: student.cardNumber,
+          firstName: student.firstName,
+          lastName: student.lastName,
+          requiresPasswordChange: student.requiresPasswordChange,
+        },
+      });
+    } catch (error) {
+      console.error("Student login failed:", error);
+      res.status(500).json({
+        success: false,
+        error: "Internal server error.",
+        errorCode: "server_error",
+      });
+    }
+  });
+
+  app.post("/api/student/change-password", async (req, res) => {
+    try {
+      const studentId = getStudentIdFromRequest(req);
+      if (!studentId) {
+        return res.status(401).json({
+          success: false,
+          error: "Authentication required.",
+          errorCode: "unauthorized",
+        });
+      }
+
+      const { currentPassword, newPassword, confirmPassword } = req.body ?? {};
+      if (!currentPassword || !newPassword || !confirmPassword) {
+        return res.status(400).json({
+          success: false,
+          error: "All password fields are required.",
+          errorCode: "missing_fields",
+        });
+      }
+
+      if (String(newPassword) !== String(confirmPassword)) {
+        return res.status(400).json({
+          success: false,
+          error: "The confirmation password does not match.",
+          errorCode: "mismatch",
+        });
+      }
+
+      if (String(newPassword).length < 8) {
+        return res.status(400).json({
+          success: false,
+          error: "The new password must contain at least 8 characters.",
+          errorCode: "weak_password",
+        });
+      }
+
+      const student = await storage.getStudentById(studentId);
+      if (!student) {
+        return res.status(404).json({
+          success: false,
+          error: "Student account not found.",
+          errorCode: "not_found",
+        });
+      }
+
+      const hashedCurrent = hashPassword(String(currentPassword));
+      const currentHash = student.passwordHash ?? student.temporaryPasswordHash;
+      if (hashedCurrent !== currentHash) {
+        return res.status(400).json({
+          success: false,
+          error: "The current password is incorrect.",
+          errorCode: "invalid_current_password",
+        });
+      }
+
+      const newHash = hashPassword(String(newPassword));
+      if (newHash === currentHash) {
+        return res.status(400).json({
+          success: false,
+          error: "Please choose a different password than your current one.",
+          errorCode: "password_reused",
+        });
+      }
+
+      const updatedStudent = await storage.updateStudentPassword(studentId, newHash);
+      if (!updatedStudent) {
+        return res.status(500).json({
+          success: false,
+          error: "Unable to update the password.",
+          errorCode: "update_failed",
+        });
+      }
+
+      const sessionToken = createStudentSessionToken(updatedStudent.id);
+
+      res.json({
+        success: true,
+        message: "Password updated successfully.",
+        sessionToken,
+        student: {
+          id: updatedStudent.id,
+          cardNumber: updatedStudent.cardNumber,
+          firstName: updatedStudent.firstName,
+          lastName: updatedStudent.lastName,
+          requiresPasswordChange: updatedStudent.requiresPasswordChange,
+        },
+      });
+    } catch (error) {
+      console.error("Student password change failed:", error);
+      res.status(500).json({
+        success: false,
+        error: "Internal server error.",
+        errorCode: "server_error",
+      });
+    }
+  });
+
+  app.get("/api/student/dashboard", async (req, res) => {
+    try {
+      const studentId = getStudentIdFromRequest(req);
+      if (!studentId) {
+        return res.status(401).json({
+          success: false,
+          error: "Authentication required.",
+          errorCode: "unauthorized",
+        });
+      }
+
+      const dashboard = await storage.getStudentDashboard(studentId);
+      if (!dashboard) {
+        return res.status(404).json({
+          success: false,
+          error: "Student account not found.",
+          errorCode: "not_found",
+        });
+      }
+
+      res.json({ success: true, data: dashboard });
+    } catch (error) {
+      console.error("Failed to load student dashboard:", error);
+      res.status(500).json({
+        success: false,
+        error: "Internal server error.",
+        errorCode: "server_error",
+      });
+    }
+  });
+
+  app.post("/api/student/store/request", async (req, res) => {
+    try {
+      const studentId = getStudentIdFromRequest(req);
+      if (!studentId) {
+        return res.status(401).json({
+          success: false,
+          error: "Authentication required.",
+          errorCode: "unauthorized",
+        });
+      }
+
+      const { courseId } = req.body ?? {};
+      const numericCourseId = Number(courseId);
+      if (!Number.isInteger(numericCourseId)) {
+        return res.status(400).json({
+          success: false,
+          error: "A valid course identifier is required.",
+          errorCode: "invalid_course",
+        });
+      }
+
+      const request = await storage.createStudentCourseRequest(studentId, numericCourseId);
+      const dashboard = await storage.getStudentDashboard(studentId);
+
+      res.json({
+        success: true,
+        request,
+        dashboard,
+      });
+    } catch (error) {
+      console.error("Failed to create course request:", error);
+      if (error instanceof Error) {
+        if (error.message === "course_not_found") {
+          return res.status(404).json({
+            success: false,
+            error: "The selected course could not be found.",
+            errorCode: "course_not_found",
+          });
+        }
+
+        if (error.message === "course_already_enrolled") {
+          return res.status(400).json({
+            success: false,
+            error: "You are already enrolled in this course.",
+            errorCode: "course_already_enrolled",
+          });
+        }
+      }
+
+      res.status(500).json({
+        success: false,
+        error: "Internal server error.",
+        errorCode: "server_error",
+      });
+    }
+  });
+
   // Contact form submission
+  app.post("/api/training-applications", async (req, res) => {
+    try {
+      const clientIP = req.ip || req.connection.remoteAddress || 'unknown';
+
+      if (isSpamSubmission(clientIP)) {
+        console.warn(`Flood protection triggered for training form IP: ${clientIP}`);
+        return res.status(429).json({
+          success: false,
+          error: "Trop de soumissions détectées. Veuillez patienter avant de soumettre à nouveau."
+        });
+      }
+
+      if (req.body.website || req.body.url || req.body.phone_hidden) {
+        console.warn(`Training form bot detected via honeypot from IP: ${clientIP}`);
+        return res.status(400).json({
+          success: false,
+          error: "Soumission invalide détectée."
+        });
+      }
+
+      const submissionStartTime = req.body.formStartTime;
+      if (submissionStartTime) {
+        const submissionTime = Date.now() - parseInt(submissionStartTime);
+        if (submissionTime < 3000) {
+          console.warn(`Training form submitted too quickly from IP: ${clientIP}, time: ${submissionTime}ms`);
+          return res.status(400).json({
+            success: false,
+            error: "Soumission trop rapide. Veuillez prendre le temps de remplir le formulaire."
+          });
+        }
+      }
+
+      const { recaptchaToken, website, url, phone_hidden, formStartTime, ...formData } = req.body;
+
+      const requiredFields = [
+        'firstName',
+        'lastName',
+        'dateOfBirth',
+        'address',
+        'phoneNumber',
+        'email',
+        'employmentStatus',
+        'motivations',
+        'careerGoals'
+      ];
+
+      const missingFields = requiredFields.filter(field => !formData[field] || String(formData[field]).trim() === '');
+      if (missingFields.length > 0) {
+        return res.status(400).json({
+          success: false,
+          error: "Tous les champs obligatoires doivent être remplis.",
+          details: missingFields
+        });
+      }
+
+      if (formData.employmentStatus === 'other' && (!formData.employmentStatusOther || String(formData.employmentStatusOther).trim() === '')) {
+        return res.status(400).json({
+          success: false,
+          error: "Veuillez préciser votre statut actuel."
+        });
+      }
+
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailRegex.test(formData.email)) {
+        return res.status(400).json({
+          success: false,
+          error: "Format d'email invalide."
+        });
+      }
+
+      const phoneDigits = String(formData.phoneNumber).replace(/\D/g, '');
+      if (phoneDigits.length < 10) {
+        return res.status(400).json({
+          success: false,
+          error: "Veuillez fournir un numéro de téléphone valide."
+        });
+      }
+
+      const birthDate = new Date(formData.dateOfBirth);
+      if (Number.isNaN(birthDate.getTime()) || birthDate > new Date()) {
+        return res.status(400).json({
+          success: false,
+          error: "La date de naissance est invalide."
+        });
+      }
+
+      const motivations = String(formData.motivations).trim();
+      const careerGoals = String(formData.careerGoals).trim();
+
+      if (motivations.length < 20 || careerGoals.length < 20) {
+        return res.status(400).json({
+          success: false,
+          error: "Merci de détailler vos motivations et objectifs professionnels."
+        });
+      }
+
+      if (!formData.declarationAccepted) {
+        return res.status(400).json({
+          success: false,
+          error: "La déclaration doit être acceptée pour soumettre votre demande."
+        });
+      }
+
+      const sanitizedData: InsertTrainingApplication = {
+        firstName: String(formData.firstName).trim(),
+        lastName: String(formData.lastName).trim(),
+        dateOfBirth: String(formData.dateOfBirth),
+        address: String(formData.address).trim(),
+        phoneNumber: String(formData.phoneNumber).trim(),
+        email: String(formData.email).trim().toLowerCase(),
+        employmentStatus: String(formData.employmentStatus),
+        employmentStatusOther: formData.employmentStatus === 'other'
+          ? String(formData.employmentStatusOther).trim()
+          : undefined,
+        motivations,
+        careerGoals,
+        declarationAccepted: true,
+      };
+
+      const validatedData = insertTrainingApplicationSchema.parse(sanitizedData);
+
+      if (!validateApplicationContent(validatedData)) {
+        console.warn(`Training application content flagged from IP: ${clientIP}`);
+        return res.status(400).json({
+          success: false,
+          error: "Le contenu du formulaire contient des éléments non autorisés."
+        });
+      }
+
+      recordSubmission(clientIP);
+
+      const application = await storage.createTrainingApplication(validatedData);
+
+      await sendTrainingApplicationToDiscord(validatedData);
+
+      console.log(`Training application submitted successfully from IP: ${clientIP}`);
+      res.json({ success: true, message: "Demande envoyée avec succès", id: application.id });
+    } catch (error) {
+      console.error("Error creating training application:", error);
+      if (error instanceof z.ZodError) {
+        res.status(400).json({ success: false, error: "Données du formulaire invalides", details: error.errors });
+      } else {
+        res.status(500).json({ success: false, error: "Erreur interne du serveur" });
+      }
+    }
+  });
+
   app.post("/api/contact", async (req, res) => {
     try {
       const clientIP = req.ip || req.connection.remoteAddress || 'unknown';

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,11 +1,60 @@
-import { 
-  users, 
+import { createHash } from "crypto";
+import {
+  users,
   contactMessages,
-  type User, 
+  trainingApplications,
+  studentAccounts,
+  studentCourses,
+  studentEnrollments,
+  studentCourseRequests,
+  type User,
   type InsertUser,
   type ContactMessage,
-  type InsertContactMessage
+  type InsertContactMessage,
+  type TrainingApplication,
+  type InsertTrainingApplication,
+  type StudentAccount,
+  type StudentCourse,
+  type StudentEnrollment,
+  type StudentCourseRequest,
 } from "@shared/schema";
+
+export interface StudentCourseSummary {
+  id: number;
+  courseId: number;
+  title: string;
+  description: string;
+  status: StudentEnrollment["status"];
+  progress: number;
+  priceCents: number;
+  updatedAt: Date;
+}
+
+export interface StudentCourseRequestSummary {
+  id: number;
+  courseId: number;
+  courseTitle: string;
+  priceCents: number;
+  status: StudentCourseRequest["status"];
+  createdAt: Date;
+}
+
+export interface StudentDashboardData {
+  student: {
+    id: number;
+    cardNumber: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    phoneNumber: string | null;
+    address: string | null;
+  };
+  activeCourses: StudentCourseSummary[];
+  inProgressCourses: StudentCourseSummary[];
+  completedCourses: StudentCourseSummary[];
+  pendingRequests: StudentCourseRequestSummary[];
+  store: StudentCourse[];
+}
 
 export interface IStorage {
   getUser(id: number): Promise<User | undefined>;
@@ -13,19 +62,177 @@ export interface IStorage {
   createUser(user: InsertUser): Promise<User>;
   createContactMessage(message: InsertContactMessage): Promise<ContactMessage>;
   getContactMessages(): Promise<ContactMessage[]>;
+  createTrainingApplication(application: InsertTrainingApplication): Promise<TrainingApplication>;
+  getTrainingApplications(): Promise<TrainingApplication[]>;
+  getStudentByCardNumber(cardNumber: string): Promise<StudentAccount | undefined>;
+  getStudentById(studentId: number): Promise<StudentAccount | undefined>;
+  updateStudentPassword(studentId: number, newPasswordHash: string): Promise<StudentAccount | undefined>;
+  getStudentDashboard(studentId: number): Promise<StudentDashboardData | null>;
+  createStudentCourseRequest(studentId: number, courseId: number): Promise<StudentCourseRequestSummary>;
+}
+
+export function hashPassword(password: string): string {
+  return createHash("sha256").update(password).digest("hex");
 }
 
 export class MemStorage implements IStorage {
   private users: Map<number, User>;
   private contactMessages: Map<number, ContactMessage>;
+  private trainingApplications: Map<number, TrainingApplication>;
+  private studentAccounts: Map<number, StudentAccount>;
+  private studentCourses: Map<number, StudentCourse>;
+  private studentEnrollments: Map<number, StudentEnrollment>;
+  private studentCourseRequests: Map<number, StudentCourseRequest>;
   private currentUserId: number;
   private currentMessageId: number;
+  private currentApplicationId: number;
+  private currentStudentAccountId: number;
+  private currentStudentCourseId: number;
+  private currentEnrollmentId: number;
+  private currentCourseRequestId: number;
 
   constructor() {
     this.users = new Map();
     this.contactMessages = new Map();
+    this.trainingApplications = new Map();
+    this.studentAccounts = new Map();
+    this.studentCourses = new Map();
+    this.studentEnrollments = new Map();
+    this.studentCourseRequests = new Map();
     this.currentUserId = 1;
     this.currentMessageId = 1;
+    this.currentApplicationId = 1;
+    this.currentStudentAccountId = 1;
+    this.currentStudentCourseId = 1;
+    this.currentEnrollmentId = 1;
+    this.currentCourseRequestId = 1;
+
+    this.seedStudentPortalData();
+  }
+
+  private seedStudentPortalData() {
+    const courses: Array<Omit<StudentCourse, "id">> = [
+      {
+        slug: "public-safety-fundamentals",
+        title: "Public Safety Fundamentals",
+        description: "Core knowledge for planning, communicating, and responding to public safety incidents.",
+        priceCents: 27500,
+        isActive: true,
+        createdAt: new Date(),
+      },
+      {
+        slug: "emergency-management-operations",
+        title: "Emergency Management Operations",
+        description: "Operational playbooks for coordinating multi-agency emergency responses.",
+        priceCents: 31500,
+        isActive: true,
+        createdAt: new Date(),
+      },
+      {
+        slug: "occupational-safety-strategies",
+        title: "Occupational Safety Strategies",
+        description: "Tools and templates to deploy compliant occupational health and safety programs.",
+        priceCents: 28900,
+        isActive: true,
+        createdAt: new Date(),
+      },
+      {
+        slug: "community-resilience-labs",
+        title: "Community Resilience Labs",
+        description: "Workshops focused on empowering francophone and bilingual community response teams.",
+        priceCents: 24900,
+        isActive: true,
+        createdAt: new Date(),
+      },
+    ];
+
+    courses.forEach((course) => {
+      const newCourse: StudentCourse = {
+        id: this.currentStudentCourseId++,
+        ...course,
+      };
+      this.studentCourses.set(newCourse.id, newCourse);
+    });
+
+    const studentOne: StudentAccount = {
+      id: this.currentStudentAccountId++,
+      cardNumber: "STU-1001",
+      email: "alex.durand@example.com",
+      firstName: "Alex",
+      lastName: "Durand",
+      phoneNumber: "613-555-0101",
+      address: "123 Main Street, Ottawa, ON",
+      temporaryPasswordHash: hashPassword("TEMP1234"),
+      passwordHash: null,
+      requiresPasswordChange: true,
+      isActive: true,
+      createdAt: new Date(),
+    };
+
+    const studentTwo: StudentAccount = {
+      id: this.currentStudentAccountId++,
+      cardNumber: "STU-2044",
+      email: "marie.dupont@example.com",
+      firstName: "Marie",
+      lastName: "Dupont",
+      phoneNumber: "437-555-0199",
+      address: "908 Rue King Est, Sherbrooke, QC",
+      temporaryPasswordHash: hashPassword("PASSINIT"),
+      passwordHash: hashPassword("Secur3Pass!"),
+      requiresPasswordChange: false,
+      isActive: true,
+      createdAt: new Date(),
+    };
+
+    this.studentAccounts.set(studentOne.id, studentOne);
+    this.studentAccounts.set(studentTwo.id, studentTwo);
+
+    const publicSafetyCourse = Array.from(this.studentCourses.values()).find(
+      (course) => course.slug === "public-safety-fundamentals",
+    );
+    const emergencyCourse = Array.from(this.studentCourses.values()).find(
+      (course) => course.slug === "emergency-management-operations",
+    );
+    const ohsCourse = Array.from(this.studentCourses.values()).find(
+      (course) => course.slug === "occupational-safety-strategies",
+    );
+
+    if (publicSafetyCourse) {
+      const enrollment: StudentEnrollment = {
+        id: this.currentEnrollmentId++,
+        studentId: studentOne.id,
+        courseId: publicSafetyCourse.id,
+        status: "active",
+        progress: 100,
+        activatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 45),
+        updatedAt: new Date(),
+      };
+      this.studentEnrollments.set(enrollment.id, enrollment);
+    }
+
+    if (emergencyCourse) {
+      const enrollment: StudentEnrollment = {
+        id: this.currentEnrollmentId++,
+        studentId: studentOne.id,
+        courseId: emergencyCourse.id,
+        status: "in-progress",
+        progress: 55,
+        activatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 14),
+        updatedAt: new Date(),
+      };
+      this.studentEnrollments.set(enrollment.id, enrollment);
+    }
+
+    if (ohsCourse) {
+      const request: StudentCourseRequest = {
+        id: this.currentCourseRequestId++,
+        studentId: studentOne.id,
+        courseId: ohsCourse.id,
+        status: "pending",
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 6),
+      };
+      this.studentCourseRequests.set(request.id, request);
+    }
   }
 
   async getUser(id: number): Promise<User | undefined> {
@@ -33,9 +240,7 @@ export class MemStorage implements IStorage {
   }
 
   async getUserByUsername(username: string): Promise<User | undefined> {
-    return Array.from(this.users.values()).find(
-      (user) => user.username === username,
-    );
+    return Array.from(this.users.values()).find((user) => user.username === username);
   }
 
   async createUser(insertUser: InsertUser): Promise<User> {
@@ -47,10 +252,10 @@ export class MemStorage implements IStorage {
 
   async createContactMessage(insertMessage: InsertContactMessage): Promise<ContactMessage> {
     const id = this.currentMessageId++;
-    const message: ContactMessage = { 
-      ...insertMessage, 
+    const message: ContactMessage = {
+      ...insertMessage,
       id,
-      createdAt: new Date()
+      createdAt: new Date(),
     };
     this.contactMessages.set(id, message);
     return message;
@@ -58,8 +263,186 @@ export class MemStorage implements IStorage {
 
   async getContactMessages(): Promise<ContactMessage[]> {
     return Array.from(this.contactMessages.values()).sort(
-      (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
     );
+  }
+
+  async createTrainingApplication(
+    insertApplication: InsertTrainingApplication,
+  ): Promise<TrainingApplication> {
+    const id = this.currentApplicationId++;
+    const application: TrainingApplication = {
+      ...insertApplication,
+      id,
+      createdAt: new Date(),
+    };
+    this.trainingApplications.set(id, application);
+    return application;
+  }
+
+  async getTrainingApplications(): Promise<TrainingApplication[]> {
+    return Array.from(this.trainingApplications.values()).sort(
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+    );
+  }
+
+  async getStudentByCardNumber(cardNumber: string): Promise<StudentAccount | undefined> {
+    const normalized = cardNumber.trim().toUpperCase();
+    return Array.from(this.studentAccounts.values()).find(
+      (student) => student.cardNumber.toUpperCase() === normalized,
+    );
+  }
+
+  async getStudentById(studentId: number): Promise<StudentAccount | undefined> {
+    return this.studentAccounts.get(studentId);
+  }
+
+  async updateStudentPassword(
+    studentId: number,
+    newPasswordHash: string,
+  ): Promise<StudentAccount | undefined> {
+    const account = this.studentAccounts.get(studentId);
+    if (!account) {
+      return undefined;
+    }
+
+    const updated: StudentAccount = {
+      ...account,
+      passwordHash: newPasswordHash,
+      temporaryPasswordHash: newPasswordHash,
+      requiresPasswordChange: false,
+    };
+    this.studentAccounts.set(studentId, updated);
+    return updated;
+  }
+
+  async getStudentDashboard(studentId: number): Promise<StudentDashboardData | null> {
+    const student = this.studentAccounts.get(studentId);
+    if (!student) {
+      return null;
+    }
+
+    const enrollments = Array.from(this.studentEnrollments.values()).filter(
+      (enrollment) => enrollment.studentId === studentId,
+    );
+    const requests = Array.from(this.studentCourseRequests.values()).filter(
+      (request) => request.studentId === studentId,
+    );
+
+    const formatEnrollment = (enrollment: StudentEnrollment): StudentCourseSummary => {
+      const course = this.studentCourses.get(enrollment.courseId);
+      return {
+        id: enrollment.id,
+        courseId: enrollment.courseId,
+        title: course?.title ?? "Course",
+        description: course?.description ?? "",
+        status: enrollment.status,
+        progress: enrollment.progress,
+        priceCents: course?.priceCents ?? 0,
+        updatedAt: enrollment.updatedAt,
+      };
+    };
+
+    const formatRequest = (
+      request: StudentCourseRequest,
+    ): StudentCourseRequestSummary => {
+      const course = this.studentCourses.get(request.courseId);
+      return {
+        id: request.id,
+        courseId: request.courseId,
+        courseTitle: course?.title ?? "Course",
+        priceCents: course?.priceCents ?? 0,
+        status: request.status,
+        createdAt: request.createdAt,
+      };
+    };
+
+    const activeCourses = enrollments
+      .filter((enrollment) => enrollment.status === "active")
+      .map(formatEnrollment);
+    const inProgressCourses = enrollments
+      .filter((enrollment) => enrollment.status === "in-progress")
+      .map(formatEnrollment);
+    const completedCourses = enrollments
+      .filter((enrollment) => enrollment.status === "completed")
+      .map(formatEnrollment);
+
+    const pendingRequests = requests.map(formatRequest);
+
+    const unavailableCourseIds = new Set<number>([
+      ...enrollments.map((enrollment) => enrollment.courseId),
+      ...requests.map((request) => request.courseId),
+    ]);
+
+    const store = Array.from(this.studentCourses.values())
+      .filter((course) => course.isActive && !unavailableCourseIds.has(course.id))
+      .map((course) => ({ ...course }));
+
+    return {
+      student: {
+        id: student.id,
+        cardNumber: student.cardNumber,
+        firstName: student.firstName,
+        lastName: student.lastName,
+        email: student.email,
+        phoneNumber: student.phoneNumber ?? null,
+        address: student.address ?? null,
+      },
+      activeCourses,
+      inProgressCourses,
+      completedCourses,
+      pendingRequests,
+      store,
+    };
+  }
+
+  async createStudentCourseRequest(
+    studentId: number,
+    courseId: number,
+  ): Promise<StudentCourseRequestSummary> {
+    const course = this.studentCourses.get(courseId);
+    if (!course || !course.isActive) {
+      throw new Error("course_not_found");
+    }
+
+    const alreadyEnrolled = Array.from(this.studentEnrollments.values()).some(
+      (enrollment) => enrollment.studentId === studentId && enrollment.courseId === courseId,
+    );
+    if (alreadyEnrolled) {
+      throw new Error("course_already_enrolled");
+    }
+
+    const existingRequest = Array.from(this.studentCourseRequests.values()).find(
+      (request) => request.studentId === studentId && request.courseId === courseId,
+    );
+    if (existingRequest) {
+      return {
+        id: existingRequest.id,
+        courseId: existingRequest.courseId,
+        courseTitle: course.title,
+        priceCents: course.priceCents,
+        status: existingRequest.status,
+        createdAt: existingRequest.createdAt,
+      };
+    }
+
+    const request: StudentCourseRequest = {
+      id: this.currentCourseRequestId++,
+      studentId,
+      courseId,
+      status: "pending",
+      createdAt: new Date(),
+    };
+    this.studentCourseRequests.set(request.id, request);
+
+    return {
+      id: request.id,
+      courseId: request.courseId,
+      courseTitle: course.title,
+      priceCents: course.priceCents,
+      status: request.status,
+      createdAt: request.createdAt,
+    };
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, boolean, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, boolean, timestamp, integer } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -19,6 +19,67 @@ export const contactMessages = pgTable("contact_messages", {
 });
 
 
+export const trainingApplications = pgTable("training_applications", {
+  id: serial("id").primaryKey(),
+  firstName: text("first_name").notNull(),
+  lastName: text("last_name").notNull(),
+  dateOfBirth: text("date_of_birth").notNull(),
+  address: text("address").notNull(),
+  phoneNumber: text("phone_number").notNull(),
+  email: text("email").notNull(),
+  employmentStatus: text("employment_status").notNull(),
+  employmentStatusOther: text("employment_status_other"),
+  motivations: text("motivations").notNull(),
+  careerGoals: text("career_goals").notNull(),
+  declarationAccepted: boolean("declaration_accepted").default(false).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+
+export const studentAccounts = pgTable("student_accounts", {
+  id: serial("id").primaryKey(),
+  cardNumber: text("card_number").notNull().unique(),
+  email: text("email").notNull(),
+  firstName: text("first_name").notNull(),
+  lastName: text("last_name").notNull(),
+  phoneNumber: text("phone_number"),
+  address: text("address"),
+  temporaryPasswordHash: text("temporary_password_hash").notNull(),
+  passwordHash: text("password_hash"),
+  requiresPasswordChange: boolean("requires_password_change").default(true).notNull(),
+  isActive: boolean("is_active").default(true).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export const studentCourses = pgTable("student_courses", {
+  id: serial("id").primaryKey(),
+  slug: text("slug").notNull().unique(),
+  title: text("title").notNull(),
+  description: text("description").notNull(),
+  priceCents: integer("price_cents").notNull(),
+  isActive: boolean("is_active").default(true).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export const studentEnrollments = pgTable("student_enrollments", {
+  id: serial("id").primaryKey(),
+  studentId: integer("student_id").notNull(),
+  courseId: integer("course_id").notNull(),
+  status: text("status").notNull(),
+  progress: integer("progress").default(0).notNull(),
+  activatedAt: timestamp("activated_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const studentCourseRequests = pgTable("student_course_requests", {
+  id: serial("id").primaryKey(),
+  studentId: integer("student_id").notNull(),
+  courseId: integer("course_id").notNull(),
+  status: text("status").default("pending").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+
 
 export const insertUserSchema = createInsertSchema(users).pick({
   username: true,
@@ -30,7 +91,43 @@ export const insertContactMessageSchema = createInsertSchema(contactMessages).om
   createdAt: true,
 });
 
+export const insertTrainingApplicationSchema = createInsertSchema(trainingApplications).omit({
+  id: true,
+  createdAt: true,
+});
+
+export const insertStudentAccountSchema = createInsertSchema(studentAccounts).omit({
+  id: true,
+  createdAt: true,
+});
+
+export const insertStudentCourseSchema = createInsertSchema(studentCourses).omit({
+  id: true,
+  createdAt: true,
+});
+
+export const insertStudentEnrollmentSchema = createInsertSchema(studentEnrollments).omit({
+  id: true,
+  activatedAt: true,
+  updatedAt: true,
+});
+
+export const insertStudentCourseRequestSchema = createInsertSchema(studentCourseRequests).omit({
+  id: true,
+  createdAt: true,
+});
+
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type User = typeof users.$inferSelect;
 export type InsertContactMessage = z.infer<typeof insertContactMessageSchema>;
 export type ContactMessage = typeof contactMessages.$inferSelect;
+export type InsertTrainingApplication = z.infer<typeof insertTrainingApplicationSchema>;
+export type TrainingApplication = typeof trainingApplications.$inferSelect;
+export type InsertStudentAccount = z.infer<typeof insertStudentAccountSchema>;
+export type StudentAccount = typeof studentAccounts.$inferSelect;
+export type InsertStudentCourse = z.infer<typeof insertStudentCourseSchema>;
+export type StudentCourse = typeof studentCourses.$inferSelect;
+export type InsertStudentEnrollment = z.infer<typeof insertStudentEnrollmentSchema>;
+export type StudentEnrollment = typeof studentEnrollments.$inferSelect;
+export type InsertStudentCourseRequest = z.infer<typeof insertStudentCourseRequestSchema>;
+export type StudentCourseRequest = typeof studentCourseRequests.$inferSelect;


### PR DESCRIPTION
## Summary
- add localized student login, password reset, and dashboard pages that persist portal sessions in the browser
- extend navigation, translations, and routing to surface the bilingual student portal experience
- implement server-side schemas, storage, Neon scaffolding, and API endpoints to authenticate students, deliver dashboard data, and queue course activation requests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8a51ad0ac8325870765d05a124790