### PR TITLE
Relocate student portal link to footer navigation

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -66,7 +66,13 @@ export const Footer = () => {
               Group
             </h3>
             <nav className="flex flex-col items-center gap-2 mt-6" aria-label={language === 'fr' ? 'Menu pied de page' : 'Footer menu'}>
-              <Link 
+              <Link
+                to={language === 'fr' ? '/etudiant/connexion' : '/student/login'}
+                className="text-[#f89422] text-sm hover:text-white transition-colors"
+              >
+                {t.studentPortal.navLabel}
+              </Link>
+              <Link
                 to={language === 'fr' ? '/politique-confidentialite' : '/privacy-policy'}
                 className="text-[#f89422] text-sm hover:text-white transition-colors"
               >

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -77,12 +77,6 @@ export const Header = () => {
           <span className="ontario-pride-text hidden md:block whitespace-nowrap">
             {language === 'fr' ? 'Fier de l\'Ontario' : 'Proud of Ontario'}
           </span>
-          <Link
-            href={language === 'fr' ? '/etudiant/connexion' : '/student/login'}
-            className="text-[#f89422] text-xs md:text-sm font-semibold hover:text-white transition-colors"
-          >
-            {t.studentPortal.navLabel}
-          </Link>
           <button
             ref={buttonRef}
             onClick={toggleLanguage}


### PR DESCRIPTION
## Summary
- remove the Student Portal link from the header navigation
- add the Student Portal link to the footer navigation menu

## Testing
- npm run dev *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'better-sqlite3')*


------
https://chatgpt.com/codex/tasks/task_e_68e869945cf8832596df7ab527b145cb