### PR TITLE
Switch error page home links to icon-only buttons

### DIFF
--- a/client/src/pages/ServerError.tsx
+++ b/client/src/pages/ServerError.tsx
@@ -47,12 +47,12 @@ export default function ServerError() {
           </Button>
           
           <Link href="/">
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               className="w-full border-[#3b82f6] text-[#3b82f6] hover:bg-[#3b82f6] hover:text-white"
+              aria-label={t.errors[500].backHome}
             >
-              <Home className="h-4 w-4 mr-2" />
-              {t.errors[500].backHome}
+              <Home className="h-4 w-4" />
             </Button>
           </Link>
           

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -35,11 +35,11 @@ export default function NotFound() {
         {/* Action Buttons */}
         <div className="space-y-4">
           <Link href="/">
-            <Button 
+            <Button
               className="w-full bg-[#f89422] hover:bg-[#f89422]/90 text-black font-semibold py-3"
+              aria-label={t.errors[404].backHome}
             >
-              <Home className="h-4 w-4 mr-2" />
-              {t.errors[404].backHome}
+              <Home className="h-4 w-4" />
             </Button>
           </Link>
           


### PR DESCRIPTION
## Summary
- remove the Back to home label from the 404/500 error buttons so they display only the icon
- keep accessibility by adding aria-labels that reuse the existing translations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f700d577f48325b0dce40152650c2e